### PR TITLE
Introduce "rigorous" mode for convergence checking

### DIFF
--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -447,21 +447,20 @@ class AdjointMeshSeq(MeshSeq):
         Check for convergence of the fixed point iteration due to the relative
         difference in QoI value being smaller than the specified tolerance.
 
-        The :attr:`AdjointMeshSeq.converged` attribute is set to ``True`` across all
-        entries if convergence is detected.
+        :return: ``True`` if QoI convergence is detected, else ``False``
         """
         if not self.check_convergence.any():
             self.info(
                 "Skipping QoI convergence check because check_convergence contains"
                 f" False values for indices {self._subintervals_not_checked}."
             )
-            return self.converged
+            return False
         if len(self.qoi_values) >= max(2, self.params.miniter + 1):
             qoi_, qoi = self.qoi_values[-2:]
             if abs(qoi - qoi_) < self.params.qoi_rtol * abs(qoi_):
-                self.converged[:] = True
                 pyrint(
                     f"QoI converged after {self.fp_iteration+1} iterations"
                     f" under relative tolerance {self.params.qoi_rtol}."
                 )
-        return self.converged
+                return True
+        return False

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -291,7 +291,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             #       can avoid unnecessary extra solves
             self.qoi_values.append(self.J)
             qoi_converged = self.check_qoi_convergence()
-            if not self.params.rigorous and qoi_converged:
+            if self.params.convergence_criteria == "any" and qoi_converged:
                 self.converged[:] = True
                 break
 
@@ -299,13 +299,13 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             ee = indicators2estimator(indicators, self.time_partition)
             self.estimator_values.append(ee)
             ee_converged = self.check_estimator_convergence()
-            if not self.params.rigorous and ee_converged:
+            if self.params.convergence_criteria == "any" and ee_converged:
                 self.converged[:] = True
                 break
 
             # Adapt meshes and log element counts
             continue_unconditionally = adaptor(self, sols, indicators)
-            if not self.params.rigorous:
+            if self.params.drop_out_converged:
                 self.check_convergence[:] = np.logical_not(
                     np.logical_or(continue_unconditionally, self.converged)
                 )
@@ -315,10 +315,10 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             # Check for element count convergence
             self.converged[:] = self.check_element_count_convergence()
             elem_converged = self.converged.all()
-            if not self.params.rigorous and elem_converged:
+            if self.params.convergence_criteria == "any" and elem_converged:
                 break
 
-            # Convergence check for rigorous mode
+            # Convergence check for 'all' mode
             if qoi_converged and ee_converged and elem_converged:
                 break
 

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -271,6 +271,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
         self.vertex_counts = [self.count_vertices()]
         self.qoi_values = []
         self.estimator_values = []
+        converged = False
         self.converged[:] = False
         self.check_convergence[:] = True
 
@@ -319,14 +320,22 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
                 break
 
             # Convergence check for 'all' mode
-            if qoi_converged and ee_converged and elem_converged:
+            converged = qoi_converged and ee_converged and elem_converged
+            if converged:
                 break
 
-        for i, conv in enumerate(self.converged):
-            if not conv:
+        if self.params.convergence_criteria == "all":
+            if not converged:
+                self.converged[:] = False
                 pyrint(
-                    f"Failed to converge on subinterval {i} in {self.params.maxiter}"
-                    " iterations."
+                    f"Failed to converge in {self.params.maxiter} iterations."
                 )
+        else:
+            for i, conv in enumerate(self.converged):
+                if not conv:
+                    pyrint(
+                        f"Failed to converge on subinterval {i} in {self.params.maxiter}"
+                        " iterations."
+                    )
 
         return sols

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -600,7 +600,7 @@ class MeshSeq:
         :return: Boolean array with ``True`` in the appropriate entry if convergence is
             detected on a subinterval.
         """
-        if self.params.rigorous:
+        if self.params.convergence_criteria == "all":
             converged = np.array([False] * len(self), dtype=bool)
         else:
             converged = self.converged
@@ -666,7 +666,7 @@ class MeshSeq:
 
             # Adapt meshes, logging element and vertex counts
             continue_unconditionally = adaptor(self, sols)
-            if not self.params.rigorous:
+            if self.params.drop_out_converged:
                 self.check_convergence[:] = np.logical_not(
                     np.logical_or(continue_unconditionally, self.converged)
                 )

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -626,6 +626,12 @@ class MeshSeq:
                             f" {self.fp_iteration+1} iterations under relative tolerance"
                             f" {self.params.element_rtol}."
                         )
+
+        # Check only early subintervals are marked as converged
+        if not converged.all():
+            first_not_converged = converged.argsort()[0]
+            converged[first_not_converged:] = False
+
         return converged
 
     @PETSc.Log.EventDecorator()

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -600,10 +600,10 @@ class MeshSeq:
         :return: Boolean array with ``True`` in the appropriate entry if convergence is
             detected on a subinterval.
         """
-        if self.params.convergence_criteria == "all":
-            converged = np.array([False] * len(self), dtype=bool)
-        else:
+        if self.params.drop_out_converged:
             converged = self.converged
+        else:
+            converged = np.array([False] * len(self), dtype=bool)
         if len(self.element_counts) >= max(2, self.params.miniter + 1):
             for i, (ne_, ne) in enumerate(zip(*self.element_counts[-2:])):
                 if not self.check_convergence[i]:
@@ -628,7 +628,7 @@ class MeshSeq:
                         )
 
         # Check only early subintervals are marked as converged
-        if not converged.all():
+        if self.params.drop_out_converged and not converged.all():
             first_not_converged = converged.argsort()[0]
             converged[first_not_converged:] = False
 

--- a/goalie/options.py
+++ b/goalie/options.py
@@ -24,7 +24,7 @@ class AdaptParameters(AttrDict):
         self["maxiter"] = 35  # Maximum iteration count
         self["element_rtol"] = 0.001  # Relative tolerance for element count
         self["convergence_criteria"] = "any"  # Mode for convergence checking
-        self["drop_out_converged"] = True  # Drop out converged subintervals?
+        self["drop_out_converged"] = False  # Drop out converged subintervals?
 
         if not isinstance(parameters, dict):
             raise TypeError(

--- a/goalie/options.py
+++ b/goalie/options.py
@@ -23,6 +23,7 @@ class AdaptParameters(AttrDict):
         self["miniter"] = 3  # Minimum iteration count
         self["maxiter"] = 35  # Maximum iteration count
         self["element_rtol"] = 0.001  # Relative tolerance for element count
+        self["rigorous"] = False  # Mode for convergence checking
 
         if not isinstance(parameters, dict):
             raise TypeError(
@@ -38,6 +39,7 @@ class AdaptParameters(AttrDict):
         self._check_type("miniter", int)
         self._check_type("maxiter", int)
         self._check_type("element_rtol", (float, int))
+        self._check_type("rigorous", bool)
 
     def _check_type(self, key, expected):
         if not isinstance(self[key], expected):

--- a/goalie/options.py
+++ b/goalie/options.py
@@ -23,7 +23,6 @@ class AdaptParameters(AttrDict):
         self["miniter"] = 3  # Minimum iteration count
         self["maxiter"] = 35  # Maximum iteration count
         self["element_rtol"] = 0.001  # Relative tolerance for element count
-        self["convergence_criteria"] = "any"  # Mode for convergence checking
         self["drop_out_converged"] = False  # Drop out converged subintervals?
 
         if not isinstance(parameters, dict):
@@ -40,8 +39,6 @@ class AdaptParameters(AttrDict):
         self._check_type("miniter", int)
         self._check_type("maxiter", int)
         self._check_type("element_rtol", (float, int))
-        self._check_type("convergence_criteria", str)
-        self._check_value("convergence_criteria", ["all", "any"])
         self._check_type("drop_out_converged", bool)
 
     def _check_type(self, key, expected):
@@ -166,11 +163,14 @@ class GoalOrientedParameters(AdaptParameters):
     def __init__(self, parameters: dict = {}):
         self["qoi_rtol"] = 0.001  # Relative tolerance for QoI
         self["estimator_rtol"] = 0.001  # Relative tolerance for estimator
+        self["convergence_criteria"] = "any"  # Mode for convergence checking
 
         super().__init__(parameters=parameters)
 
         self._check_type("qoi_rtol", (float, int))
         self._check_type("estimator_rtol", (float, int))
+        self._check_type("convergence_criteria", str)
+        self._check_value("convergence_criteria", ["all", "any"])
 
 
 class GoalOrientedMetricParameters(GoalOrientedParameters, MetricParameters):

--- a/goalie/options.py
+++ b/goalie/options.py
@@ -23,7 +23,8 @@ class AdaptParameters(AttrDict):
         self["miniter"] = 3  # Minimum iteration count
         self["maxiter"] = 35  # Maximum iteration count
         self["element_rtol"] = 0.001  # Relative tolerance for element count
-        self["rigorous"] = False  # Mode for convergence checking
+        self["convergence_criteria"] = "any"  # Mode for convergence checking
+        self["drop_out_converged"] = True  # Drop out converged subintervals?
 
         if not isinstance(parameters, dict):
             raise TypeError(
@@ -39,7 +40,9 @@ class AdaptParameters(AttrDict):
         self._check_type("miniter", int)
         self._check_type("maxiter", int)
         self._check_type("element_rtol", (float, int))
-        self._check_type("rigorous", bool)
+        self._check_type("convergence_criteria", str)
+        self._check_value("convergence_criteria", ["all", "any"])
+        self._check_type("drop_out_converged", bool)
 
     def _check_type(self, key, expected):
         if not isinstance(self[key], expected):
@@ -50,6 +53,13 @@ class AdaptParameters(AttrDict):
             raise TypeError(
                 f"Expected attribute '{key}' to be of type '{name}', not"
                 f" '{type(self[key]).__name__}'."
+            )
+
+    def _check_value(self, key, possibilities):
+        value = self[key]
+        if value not in possibilities:
+            raise ValueError(
+                f"Unsupported value '{value}' for '{key}'. Choose from {possibilities}."
             )
 
     def __str__(self) -> str:

--- a/test/test_mesh_seq.py
+++ b/test/test_mesh_seq.py
@@ -1,6 +1,7 @@
 """
 Testing for the mesh sequence objects.
 """
+from goalie.options import AdaptParameters
 from goalie.mesh_seq import MeshSeq
 from goalie.time_partition import TimePartition, TimeInterval
 from firedrake import *
@@ -58,18 +59,21 @@ class TestGeneric(unittest.TestCase):
         self.assertEqual(str(cm.exception), msg)
 
     def test_element_convergence_lt_miniter(self):
-        mesh_seq = MeshSeq(self.time_interval, [UnitTriangleMesh()])
+        ap = AdaptParameters({"drop_out_converged": True})
+        mesh_seq = MeshSeq(self.time_interval, [UnitTriangleMesh()], parameters=ap)
         mesh_seq.check_element_count_convergence()
         self.assertFalse(mesh_seq.converged)
 
     def test_element_convergence_true(self):
-        mesh_seq = MeshSeq(self.time_interval, [UnitTriangleMesh()])
+        ap = AdaptParameters({"drop_out_converged": True})
+        mesh_seq = MeshSeq(self.time_interval, [UnitTriangleMesh()], parameters=ap)
         mesh_seq.element_counts = np.ones((mesh_seq.params.miniter + 1, 1))
         mesh_seq.check_element_count_convergence()
         self.assertTrue(mesh_seq.converged)
 
     def test_element_convergence_false(self):
-        mesh_seq = MeshSeq(self.time_interval, [UnitSquareMesh(1, 1)])
+        ap = AdaptParameters({"drop_out_converged": True})
+        mesh_seq = MeshSeq(self.time_interval, [UnitSquareMesh(1, 1)], parameters=ap)
         mesh_seq.element_counts = np.ones((mesh_seq.params.miniter + 1, 1))
         mesh_seq.element_counts[-1] = 2
         mesh_seq.check_element_count_convergence()

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -15,7 +15,6 @@ class TestAdaptParameters(unittest.TestCase):
             "miniter": 3,
             "maxiter": 35,
             "element_rtol": 0.001,
-            "convergence_criteria": "any",
             "drop_out_converged": False,
         }
 
@@ -44,7 +43,6 @@ class TestAdaptParameters(unittest.TestCase):
         self.assertEqual(ap.miniter, ap["miniter"])
         self.assertEqual(ap.maxiter, ap["maxiter"])
         self.assertEqual(ap.element_rtol, ap["element_rtol"])
-        self.assertEqual(ap.convergence_criteria, ap["convergence_criteria"])
         self.assertEqual(ap.drop_out_converged, ap["drop_out_converged"])
 
     def test_str(self):
@@ -55,7 +53,7 @@ class TestAdaptParameters(unittest.TestCase):
         ap = AdaptParameters()
         expected = (
             "AdaptParameters(miniter=3, maxiter=35, element_rtol=0.001,"
-            " convergence_criteria=any, drop_out_converged=False)"
+            " drop_out_converged=False)"
         )
         self.assertEqual(repr(ap), expected)
 
@@ -77,24 +75,10 @@ class TestAdaptParameters(unittest.TestCase):
         msg = "Expected attribute 'element_rtol' to be of type 'float' or 'int', not 'str'."
         self.assertEqual(str(cm.exception), msg)
 
-    def test_convergence_criteria_type_error(self):
-        with self.assertRaises(TypeError) as cm:
-            AdaptParameters({"convergence_criteria": 0})
-        msg = (
-            "Expected attribute 'convergence_criteria' to be of type 'str', not 'int'."
-        )
-        self.assertEqual(str(cm.exception), msg)
-
     def test_drop_out_converged_type_error(self):
         with self.assertRaises(TypeError) as cm:
             AdaptParameters({"drop_out_converged": 0})
         msg = "Expected attribute 'drop_out_converged' to be of type 'bool', not 'int'."
-        self.assertEqual(str(cm.exception), msg)
-
-    def test_convergence_criteria_value_error(self):
-        with self.assertRaises(ValueError) as cm:
-            AdaptParameters({"convergence_criteria": "both"})
-        msg = "Unsupported value 'both' for 'convergence_criteria'. Choose from ['all', 'any']."
         self.assertEqual(str(cm.exception), msg)
 
 
@@ -124,7 +108,6 @@ class TestMetricParameters(unittest.TestCase):
             "miniter": 3,
             "maxiter": 35,
             "element_rtol": 0.001,
-            "convergence_criteria": "any",
             "drop_out_converged": False,
         }
 
@@ -146,7 +129,7 @@ class TestMetricParameters(unittest.TestCase):
             " hausdorff_number=0.01, gradation_factor=1.3,"
             " no_insert=False, no_swap=False, no_move=False, no_surf=False,"
             " num_parmmg_iterations=3, miniter=3, maxiter=35, element_rtol=0.001,"
-            " convergence_criteria=any, drop_out_converged=False)"
+            " drop_out_converged=False)"
         )
         self.assertEqual(repr(ap), expected)
 
@@ -247,10 +230,10 @@ class TestGoalOrientedParameters(unittest.TestCase):
         self.defaults = {
             "qoi_rtol": 0.001,
             "estimator_rtol": 0.001,
+            "convergence_criteria": "any",
             "miniter": 3,
             "maxiter": 35,
             "element_rtol": 0.001,
-            "convergence_criteria": "any",
             "drop_out_converged": False,
         }
 
@@ -266,11 +249,25 @@ class TestGoalOrientedParameters(unittest.TestCase):
     def test_repr(self):
         ap = GoalOrientedParameters()
         expected = (
-            "GoalOrientedParameters(qoi_rtol=0.001, estimator_rtol=0.001, miniter=3,"
-            " maxiter=35, element_rtol=0.001, convergence_criteria=any,"
+            "GoalOrientedParameters(qoi_rtol=0.001, estimator_rtol=0.001,"
+            " convergence_criteria=any, miniter=3, maxiter=35, element_rtol=0.001,"
             " drop_out_converged=False)"
         )
         self.assertEqual(repr(ap), expected)
+
+    def test_convergence_criteria_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            GoalOrientedParameters({"convergence_criteria": 0})
+        msg = (
+            "Expected attribute 'convergence_criteria' to be of type 'str', not 'int'."
+        )
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_convergence_criteria_value_error(self):
+        with self.assertRaises(ValueError) as cm:
+            GoalOrientedParameters({"convergence_criteria": "both"})
+        msg = "Unsupported value 'both' for 'convergence_criteria'. Choose from ['all', 'any']."
+        self.assertEqual(str(cm.exception), msg)
 
     def test_qoi_rtol_type_error(self):
         with self.assertRaises(TypeError) as cm:
@@ -297,6 +294,7 @@ class TestGoalOrientedMetricParameters(unittest.TestCase):
         self.defaults = {
             "qoi_rtol": 0.001,
             "estimator_rtol": 0.001,
+            "convergence_criteria": "any",
             "num_ramp_iterations": 3,
             "verbosity": -1,
             "p": 1.0,
@@ -316,7 +314,6 @@ class TestGoalOrientedMetricParameters(unittest.TestCase):
             "miniter": 3,
             "maxiter": 35,
             "element_rtol": 0.001,
-            "convergence_criteria": "any",
             "drop_out_converged": False,
         }
 
@@ -333,12 +330,12 @@ class TestGoalOrientedMetricParameters(unittest.TestCase):
         ap = GoalOrientedMetricParameters()
         expected = (
             "GoalOrientedMetricParameters(qoi_rtol=0.001, estimator_rtol=0.001,"
-            " num_ramp_iterations=3, verbosity=-1, p=1.0, base_complexity=200.0,"
-            " target_complexity=4000.0, h_min=1e-30, h_max=1e+30, a_max=100000.0,"
-            " restrict_anisotropy_first=False, hausdorff_number=0.01,"
-            " gradation_factor=1.3, no_insert=False, no_swap=False, no_move=False,"
-            " no_surf=False, num_parmmg_iterations=3, miniter=3, maxiter=35,"
-            " element_rtol=0.001, convergence_criteria=any, drop_out_converged=False)"
+            " convergence_criteria=any, num_ramp_iterations=3, verbosity=-1, p=1.0,"
+            " base_complexity=200.0, target_complexity=4000.0, h_min=1e-30,"
+            " h_max=1e+30, a_max=100000.0, restrict_anisotropy_first=False,"
+            " hausdorff_number=0.01, gradation_factor=1.3, no_insert=False,"
+            " no_swap=False, no_move=False, no_surf=False, num_parmmg_iterations=3,"
+            " miniter=3, maxiter=35, element_rtol=0.001, drop_out_converged=False)"
         )
         self.assertEqual(repr(ap), expected)
 

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -11,7 +11,13 @@ class TestAdaptParameters(unittest.TestCase):
     """
 
     def setUp(self):
-        self.defaults = {"miniter": 3, "maxiter": 35, "element_rtol": 0.001, "rigorous": False}
+        self.defaults = {
+            "miniter": 3,
+            "maxiter": 35,
+            "element_rtol": 0.001,
+            "convergence_criteria": "any",
+            "drop_out_converged": True,
+        }
 
     def test_input(self):
         with self.assertRaises(TypeError) as cm:
@@ -38,7 +44,8 @@ class TestAdaptParameters(unittest.TestCase):
         self.assertEqual(ap.miniter, ap["miniter"])
         self.assertEqual(ap.maxiter, ap["maxiter"])
         self.assertEqual(ap.element_rtol, ap["element_rtol"])
-        self.assertEqual(ap.rigorous, ap["rigorous"])
+        self.assertEqual(ap.convergence_criteria, ap["convergence_criteria"])
+        self.assertEqual(ap.drop_out_converged, ap["drop_out_converged"])
 
     def test_str(self):
         ap = AdaptParameters()
@@ -46,7 +53,10 @@ class TestAdaptParameters(unittest.TestCase):
 
     def test_repr(self):
         ap = AdaptParameters()
-        expected = "AdaptParameters(miniter=3, maxiter=35, element_rtol=0.001, rigorous=False)"
+        expected = (
+            "AdaptParameters(miniter=3, maxiter=35, element_rtol=0.001,"
+            " convergence_criteria=any, drop_out_converged=True)"
+        )
         self.assertEqual(repr(ap), expected)
 
     def test_miniter_type_error(self):
@@ -67,10 +77,18 @@ class TestAdaptParameters(unittest.TestCase):
         msg = "Expected attribute 'element_rtol' to be of type 'float' or 'int', not 'str'."
         self.assertEqual(str(cm.exception), msg)
 
-    def test_rigorous_type_error(self):
+    def test_convergence_criteria_type_error(self):
         with self.assertRaises(TypeError) as cm:
-            AdaptParameters({"rigorous": 0})
-        msg = "Expected attribute 'rigorous' to be of type 'bool', not 'int'."
+            AdaptParameters({"convergence_criteria": 0})
+        msg = (
+            "Expected attribute 'convergence_criteria' to be of type 'str', not 'int'."
+        )
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_drop_out_converged_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            AdaptParameters({"drop_out_converged": 0})
+        msg = "Expected attribute 'drop_out_converged' to be of type 'bool', not 'int'."
         self.assertEqual(str(cm.exception), msg)
 
 
@@ -100,7 +118,8 @@ class TestMetricParameters(unittest.TestCase):
             "miniter": 3,
             "maxiter": 35,
             "element_rtol": 0.001,
-            "rigorous": False,
+            "convergence_criteria": "any",
+            "drop_out_converged": True,
         }
 
     def test_defaults(self):
@@ -121,7 +140,7 @@ class TestMetricParameters(unittest.TestCase):
             " hausdorff_number=0.01, gradation_factor=1.3,"
             " no_insert=False, no_swap=False, no_move=False, no_surf=False,"
             " num_parmmg_iterations=3, miniter=3, maxiter=35, element_rtol=0.001,"
-            " rigorous=False)"
+            " convergence_criteria=any, drop_out_converged=True)"
         )
         self.assertEqual(repr(ap), expected)
 
@@ -225,7 +244,8 @@ class TestGoalOrientedParameters(unittest.TestCase):
             "miniter": 3,
             "maxiter": 35,
             "element_rtol": 0.001,
-            "rigorous": False,
+            "convergence_criteria": "any",
+            "drop_out_converged": True,
         }
 
     def test_defaults(self):
@@ -241,7 +261,8 @@ class TestGoalOrientedParameters(unittest.TestCase):
         ap = GoalOrientedParameters()
         expected = (
             "GoalOrientedParameters(qoi_rtol=0.001, estimator_rtol=0.001, miniter=3,"
-            " maxiter=35, element_rtol=0.001, rigorous=False)"
+            " maxiter=35, element_rtol=0.001, convergence_criteria=any,"
+            " drop_out_converged=True)"
         )
         self.assertEqual(repr(ap), expected)
 
@@ -289,7 +310,8 @@ class TestGoalOrientedMetricParameters(unittest.TestCase):
             "miniter": 3,
             "maxiter": 35,
             "element_rtol": 0.001,
-            "rigorous": False,
+            "convergence_criteria": "any",
+            "drop_out_converged": True,
         }
 
     def test_defaults(self):
@@ -310,7 +332,7 @@ class TestGoalOrientedMetricParameters(unittest.TestCase):
             " restrict_anisotropy_first=False, hausdorff_number=0.01,"
             " gradation_factor=1.3, no_insert=False, no_swap=False, no_move=False,"
             " no_surf=False, num_parmmg_iterations=3, miniter=3, maxiter=35,"
-            " element_rtol=0.001, rigorous=False)"
+            " element_rtol=0.001, convergence_criteria=any, drop_out_converged=True)"
         )
         self.assertEqual(repr(ap), expected)
 

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -16,7 +16,7 @@ class TestAdaptParameters(unittest.TestCase):
             "maxiter": 35,
             "element_rtol": 0.001,
             "convergence_criteria": "any",
-            "drop_out_converged": True,
+            "drop_out_converged": False,
         }
 
     def test_input(self):
@@ -55,7 +55,7 @@ class TestAdaptParameters(unittest.TestCase):
         ap = AdaptParameters()
         expected = (
             "AdaptParameters(miniter=3, maxiter=35, element_rtol=0.001,"
-            " convergence_criteria=any, drop_out_converged=True)"
+            " convergence_criteria=any, drop_out_converged=False)"
         )
         self.assertEqual(repr(ap), expected)
 
@@ -125,7 +125,7 @@ class TestMetricParameters(unittest.TestCase):
             "maxiter": 35,
             "element_rtol": 0.001,
             "convergence_criteria": "any",
-            "drop_out_converged": True,
+            "drop_out_converged": False,
         }
 
     def test_defaults(self):
@@ -146,7 +146,7 @@ class TestMetricParameters(unittest.TestCase):
             " hausdorff_number=0.01, gradation_factor=1.3,"
             " no_insert=False, no_swap=False, no_move=False, no_surf=False,"
             " num_parmmg_iterations=3, miniter=3, maxiter=35, element_rtol=0.001,"
-            " convergence_criteria=any, drop_out_converged=True)"
+            " convergence_criteria=any, drop_out_converged=False)"
         )
         self.assertEqual(repr(ap), expected)
 
@@ -251,7 +251,7 @@ class TestGoalOrientedParameters(unittest.TestCase):
             "maxiter": 35,
             "element_rtol": 0.001,
             "convergence_criteria": "any",
-            "drop_out_converged": True,
+            "drop_out_converged": False,
         }
 
     def test_defaults(self):
@@ -268,7 +268,7 @@ class TestGoalOrientedParameters(unittest.TestCase):
         expected = (
             "GoalOrientedParameters(qoi_rtol=0.001, estimator_rtol=0.001, miniter=3,"
             " maxiter=35, element_rtol=0.001, convergence_criteria=any,"
-            " drop_out_converged=True)"
+            " drop_out_converged=False)"
         )
         self.assertEqual(repr(ap), expected)
 
@@ -317,7 +317,7 @@ class TestGoalOrientedMetricParameters(unittest.TestCase):
             "maxiter": 35,
             "element_rtol": 0.001,
             "convergence_criteria": "any",
-            "drop_out_converged": True,
+            "drop_out_converged": False,
         }
 
     def test_defaults(self):
@@ -338,7 +338,7 @@ class TestGoalOrientedMetricParameters(unittest.TestCase):
             " restrict_anisotropy_first=False, hausdorff_number=0.01,"
             " gradation_factor=1.3, no_insert=False, no_swap=False, no_move=False,"
             " no_surf=False, num_parmmg_iterations=3, miniter=3, maxiter=35,"
-            " element_rtol=0.001, convergence_criteria=any, drop_out_converged=True)"
+            " element_rtol=0.001, convergence_criteria=any, drop_out_converged=False)"
         )
         self.assertEqual(repr(ap), expected)
 

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -91,6 +91,12 @@ class TestAdaptParameters(unittest.TestCase):
         msg = "Expected attribute 'drop_out_converged' to be of type 'bool', not 'int'."
         self.assertEqual(str(cm.exception), msg)
 
+    def test_convergence_criteria_value_error(self):
+        with self.assertRaises(ValueError) as cm:
+            AdaptParameters({"convergence_criteria": "both"})
+        msg = "Unsupported value 'both' for 'convergence_criteria'. Choose from ['all', 'any']."
+        self.assertEqual(str(cm.exception), msg)
+
 
 class TestMetricParameters(unittest.TestCase):
     """

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -11,7 +11,7 @@ class TestAdaptParameters(unittest.TestCase):
     """
 
     def setUp(self):
-        self.defaults = {"miniter": 3, "maxiter": 35, "element_rtol": 0.001}
+        self.defaults = {"miniter": 3, "maxiter": 35, "element_rtol": 0.001, "rigorous": False}
 
     def test_input(self):
         with self.assertRaises(TypeError) as cm:
@@ -38,6 +38,7 @@ class TestAdaptParameters(unittest.TestCase):
         self.assertEqual(ap.miniter, ap["miniter"])
         self.assertEqual(ap.maxiter, ap["maxiter"])
         self.assertEqual(ap.element_rtol, ap["element_rtol"])
+        self.assertEqual(ap.rigorous, ap["rigorous"])
 
     def test_str(self):
         ap = AdaptParameters()
@@ -45,7 +46,7 @@ class TestAdaptParameters(unittest.TestCase):
 
     def test_repr(self):
         ap = AdaptParameters()
-        expected = "AdaptParameters(miniter=3, maxiter=35, element_rtol=0.001)"
+        expected = "AdaptParameters(miniter=3, maxiter=35, element_rtol=0.001, rigorous=False)"
         self.assertEqual(repr(ap), expected)
 
     def test_miniter_type_error(self):
@@ -64,6 +65,12 @@ class TestAdaptParameters(unittest.TestCase):
         with self.assertRaises(TypeError) as cm:
             AdaptParameters({"element_rtol": "0.001"})
         msg = "Expected attribute 'element_rtol' to be of type 'float' or 'int', not 'str'."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_rigorous_type_error(self):
+        with self.assertRaises(TypeError) as cm:
+            AdaptParameters({"rigorous": 0})
+        msg = "Expected attribute 'rigorous' to be of type 'bool', not 'int'."
         self.assertEqual(str(cm.exception), msg)
 
 
@@ -93,6 +100,7 @@ class TestMetricParameters(unittest.TestCase):
             "miniter": 3,
             "maxiter": 35,
             "element_rtol": 0.001,
+            "rigorous": False,
         }
 
     def test_defaults(self):
@@ -112,7 +120,8 @@ class TestMetricParameters(unittest.TestCase):
             " h_max=1e+30, a_max=100000.0, restrict_anisotropy_first=False,"
             " hausdorff_number=0.01, gradation_factor=1.3,"
             " no_insert=False, no_swap=False, no_move=False, no_surf=False,"
-            " num_parmmg_iterations=3, miniter=3, maxiter=35, element_rtol=0.001)"
+            " num_parmmg_iterations=3, miniter=3, maxiter=35, element_rtol=0.001,"
+            " rigorous=False)"
         )
         self.assertEqual(repr(ap), expected)
 
@@ -216,6 +225,7 @@ class TestGoalOrientedParameters(unittest.TestCase):
             "miniter": 3,
             "maxiter": 35,
             "element_rtol": 0.001,
+            "rigorous": False,
         }
 
     def test_defaults(self):
@@ -231,7 +241,7 @@ class TestGoalOrientedParameters(unittest.TestCase):
         ap = GoalOrientedParameters()
         expected = (
             "GoalOrientedParameters(qoi_rtol=0.001, estimator_rtol=0.001, miniter=3,"
-            " maxiter=35, element_rtol=0.001)"
+            " maxiter=35, element_rtol=0.001, rigorous=False)"
         )
         self.assertEqual(repr(ap), expected)
 
@@ -279,6 +289,7 @@ class TestGoalOrientedMetricParameters(unittest.TestCase):
             "miniter": 3,
             "maxiter": 35,
             "element_rtol": 0.001,
+            "rigorous": False,
         }
 
     def test_defaults(self):
@@ -299,7 +310,7 @@ class TestGoalOrientedMetricParameters(unittest.TestCase):
             " restrict_anisotropy_first=False, hausdorff_number=0.01,"
             " gradation_factor=1.3, no_insert=False, no_swap=False, no_move=False,"
             " no_surf=False, num_parmmg_iterations=3, miniter=3, maxiter=35,"
-            " element_rtol=0.001)"
+            " element_rtol=0.001, rigorous=False)"
         )
         self.assertEqual(repr(ap), expected)
 

--- a/test_adjoint/test_adjoint.py
+++ b/test_adjoint/test_adjoint.py
@@ -44,21 +44,18 @@ class TestAdjointMeshSeqGeneric(unittest.TestCase):
 
     def test_qoi_convergence_lt_miniter(self):
         mesh_seq = AdjointMeshSeq(self.time_interval, self.meshes, qoi_type="end_time")
-        mesh_seq.check_qoi_convergence()
-        self.assertFalse(mesh_seq.converged)
+        self.assertFalse(mesh_seq.check_qoi_convergence())
 
     def test_qoi_convergence_true(self):
         mesh_seq = AdjointMeshSeq(self.time_interval, self.meshes, qoi_type="end_time")
         mesh_seq.qoi_values = np.ones((mesh_seq.params.miniter + 1, 1))
-        mesh_seq.check_qoi_convergence()
-        self.assertTrue(mesh_seq.converged)
+        self.assertTrue(mesh_seq.check_qoi_convergence())
 
     def test_qoi_convergence_false(self):
         mesh_seq = AdjointMeshSeq(self.time_interval, self.meshes, qoi_type="end_time")
         mesh_seq.qoi_values = np.ones((mesh_seq.params.miniter + 1, 1))
         mesh_seq.qoi_values[-1] = 2
-        mesh_seq.check_qoi_convergence()
-        self.assertFalse(mesh_seq.converged)
+        self.assertFalse(mesh_seq.check_qoi_convergence())
 
 
 # ---------------------------

--- a/test_adjoint/test_fp_iteration.py
+++ b/test_adjoint/test_fp_iteration.py
@@ -96,7 +96,7 @@ class TestMeshSeq(unittest.TestCase):
 
         def adaptor(mesh_seq, sols):
             mesh_seq[0] = mesh1 if mesh_seq.fp_iteration % 2 == 0 else mesh2
-            return [False]
+            return [False, False]
 
         mesh_seq.fixed_point_iteration(adaptor)
         expected = [[1, 1], [2, 1], [1, 1], [2, 1], [1, 1], [2, 1]]
@@ -165,7 +165,7 @@ class TestGoalOrientedMeshSeq(unittest.TestCase):
 
         def adaptor(mesh_seq, sols, indicators):
             mesh_seq[0] = mesh1 if mesh_seq.fp_iteration % 2 == 0 else mesh2
-            return [False]
+            return [False, False]
 
         mesh_seq.fixed_point_iteration(adaptor)
         expected = [[1, 1], [2, 1], [1, 1], [2, 1], [1, 1], [2, 1]]

--- a/test_adjoint/test_fp_iteration.py
+++ b/test_adjoint/test_fp_iteration.py
@@ -112,7 +112,9 @@ class TestMeshSeq(unittest.TestCase):
         mesh1 = UnitSquareMesh(1, 1)
         mesh2 = UnitTriangleMesh()
         time_partition = TimePartition(1.0, 2, [0.5, 0.5], [])
-        mesh_seq = self.mesh_seq(time_partition, mesh2)
+        ap = AdaptParameters(self.parameters)
+        ap.update({"drop_out_converged": True})
+        mesh_seq = self.mesh_seq(time_partition, mesh2, parameters=ap)
 
         def adaptor(mesh_seq, sols):
             mesh_seq[0] = mesh1 if mesh_seq.fp_iteration % 2 == 0 else mesh2
@@ -200,7 +202,9 @@ class TestGoalOrientedMeshSeq(unittest.TestCase):
         mesh1 = UnitSquareMesh(1, 1)
         mesh2 = UnitTriangleMesh()
         time_partition = TimePartition(1.0, 2, [0.5, 0.5], [])
-        mesh_seq = self.mesh_seq(time_partition, mesh2, qoi_type="end_time")
+        ap = GoalOrientedParameters(self.parameters)
+        ap.update({"drop_out_converged": True})
+        mesh_seq = self.mesh_seq(time_partition, mesh2, parameters=ap, qoi_type="end_time")
 
         def adaptor(mesh_seq, sols, indicators):
             mesh_seq[0] = mesh1 if mesh_seq.fp_iteration % 2 == 0 else mesh2

--- a/test_adjoint/test_fp_iteration.py
+++ b/test_adjoint/test_fp_iteration.py
@@ -211,3 +211,18 @@ class TestGoalOrientedMeshSeq(unittest.TestCase):
         self.assertEqual(mesh_seq.element_counts, expected)
         self.assertTrue(np.allclose(mesh_seq.converged, [False, False]))
         self.assertTrue(np.allclose(mesh_seq.check_convergence, [True, True]))
+
+    def test_convergence_criteria_all(self):
+        mesh = UnitSquareMesh(1, 1)
+        time_partition = TimePartition(1.0, 1, 0.5, [])
+        ap = GoalOrientedParameters(self.parameters)
+        ap.update({"convergence_criteria": "all"})
+        mesh_seq = self.mesh_seq(time_partition, mesh, parameters=ap, qoi_type="end_time")
+
+        def adaptor(mesh_seq, sols, indicators):
+            return [False]
+
+        mesh_seq.fixed_point_iteration(adaptor)
+        self.assertTrue(np.allclose(mesh_seq.element_counts, 2))
+        self.assertTrue(np.allclose(mesh_seq.converged, False))
+        self.assertTrue(np.allclose(mesh_seq.check_convergence, True))

--- a/test_adjoint/test_fp_iteration.py
+++ b/test_adjoint/test_fp_iteration.py
@@ -104,6 +104,22 @@ class TestMeshSeq(unittest.TestCase):
         self.assertTrue(np.allclose(mesh_seq.converged, [True, False]))
         self.assertTrue(np.allclose(mesh_seq.check_convergence, [False, True]))
 
+    def test_no_late_convergence(self):
+        mesh1 = UnitSquareMesh(1, 1)
+        mesh2 = UnitTriangleMesh()
+        time_partition = TimePartition(1.0, 2, [0.5, 0.5], [])
+        mesh_seq = self.mesh_seq(time_partition, mesh2)
+
+        def adaptor(mesh_seq, sols):
+            mesh_seq[0] = mesh1 if mesh_seq.fp_iteration % 2 == 0 else mesh2
+            return [False, False]
+
+        mesh_seq.fixed_point_iteration(adaptor)
+        expected = [[1, 1], [2, 1], [1, 1], [2, 1], [1, 1], [2, 1]]
+        self.assertEqual(mesh_seq.element_counts, expected)
+        self.assertTrue(np.allclose(mesh_seq.converged, [False, False]))
+        self.assertTrue(np.allclose(mesh_seq.check_convergence, [True, True]))
+
 
 class TestGoalOrientedMeshSeq(unittest.TestCase):
     """
@@ -172,3 +188,19 @@ class TestGoalOrientedMeshSeq(unittest.TestCase):
         self.assertEqual(mesh_seq.element_counts, expected)
         self.assertTrue(np.allclose(mesh_seq.converged, [True, False]))
         self.assertTrue(np.allclose(mesh_seq.check_convergence, [False, True]))
+
+    def test_no_late_convergence(self):
+        mesh1 = UnitSquareMesh(1, 1)
+        mesh2 = UnitTriangleMesh()
+        time_partition = TimePartition(1.0, 2, [0.5, 0.5], [])
+        mesh_seq = self.mesh_seq(time_partition, mesh2, qoi_type="end_time")
+
+        def adaptor(mesh_seq, sols, indicators):
+            mesh_seq[0] = mesh1 if mesh_seq.fp_iteration % 2 == 0 else mesh2
+            return [False, False]
+
+        mesh_seq.fixed_point_iteration(adaptor)
+        expected = [[1, 1], [2, 1], [1, 1], [2, 1], [1, 1], [2, 1]]
+        self.assertEqual(mesh_seq.element_counts, expected)
+        self.assertTrue(np.allclose(mesh_seq.converged, [False, False]))
+        self.assertTrue(np.allclose(mesh_seq.check_convergence, [True, True]))

--- a/test_adjoint/test_fp_iteration.py
+++ b/test_adjoint/test_fp_iteration.py
@@ -95,14 +95,14 @@ class TestMeshSeq(unittest.TestCase):
         mesh_seq = self.mesh_seq(time_partition, mesh2)
 
         def adaptor(mesh_seq, sols):
-            mesh_seq[0] = mesh1 if mesh_seq.fp_iteration % 2 == 0 else mesh2
+            mesh_seq[1] = mesh1 if mesh_seq.fp_iteration % 2 == 0 else mesh2
             return [False, False]
 
         mesh_seq.fixed_point_iteration(adaptor)
-        expected = [[1, 1], [2, 1], [1, 1], [2, 1], [1, 1], [2, 1]]
+        expected = [[1, 1], [1, 2], [1, 1], [1, 2], [1, 1], [1, 2]]
         self.assertEqual(mesh_seq.element_counts, expected)
-        self.assertTrue(np.allclose(mesh_seq.converged, [False, True]))
-        self.assertTrue(np.allclose(mesh_seq.check_convergence, [True, False]))
+        self.assertTrue(np.allclose(mesh_seq.converged, [True, False]))
+        self.assertTrue(np.allclose(mesh_seq.check_convergence, [False, True]))
 
 
 class TestGoalOrientedMeshSeq(unittest.TestCase):
@@ -164,11 +164,11 @@ class TestGoalOrientedMeshSeq(unittest.TestCase):
         mesh_seq = self.mesh_seq(time_partition, mesh2, qoi_type="end_time")
 
         def adaptor(mesh_seq, sols, indicators):
-            mesh_seq[0] = mesh1 if mesh_seq.fp_iteration % 2 == 0 else mesh2
+            mesh_seq[1] = mesh1 if mesh_seq.fp_iteration % 2 == 0 else mesh2
             return [False, False]
 
         mesh_seq.fixed_point_iteration(adaptor)
-        expected = [[1, 1], [2, 1], [1, 1], [2, 1], [1, 1], [2, 1]]
+        expected = [[1, 1], [1, 2], [1, 1], [1, 2], [1, 1], [1, 2]]
         self.assertEqual(mesh_seq.element_counts, expected)
-        self.assertTrue(np.allclose(mesh_seq.converged, [False, True]))
-        self.assertTrue(np.allclose(mesh_seq.check_convergence, [True, False]))
+        self.assertTrue(np.allclose(mesh_seq.converged, [True, False]))
+        self.assertTrue(np.allclose(mesh_seq.check_convergence, [False, True]))

--- a/test_adjoint/test_utils.py
+++ b/test_adjoint/test_utils.py
@@ -106,27 +106,23 @@ class TestAdjointUtils(unittest.TestCase):
         mesh_seq = self.mesh_seq("end_time")
         mesh_seq.fp_iteration = mesh_seq.params.miniter + 1
         mesh_seq.qoi_values = [1.0]
-        mesh_seq.check_qoi_convergence()
-        self.assertFalse(mesh_seq.converged[0])
+        self.assertFalse(mesh_seq.check_qoi_convergence())
 
     def test_qoi_convergence_values_lt_miniter(self):
         mesh_seq = self.mesh_seq("end_time")
         mesh_seq.fp_iteration = mesh_seq.params.miniter
         mesh_seq.qoi_values = np.ones(mesh_seq.params.miniter - 1)
-        mesh_seq.check_qoi_convergence()
-        self.assertFalse(mesh_seq.converged[0])
+        self.assertFalse(mesh_seq.check_qoi_convergence())
 
     def test_qoi_convergence_values_constant(self):
         mesh_seq = self.mesh_seq("end_time")
         mesh_seq.fp_iteration = mesh_seq.params.miniter
         mesh_seq.qoi_values = np.ones(mesh_seq.params.miniter + 1)
-        mesh_seq.check_qoi_convergence()
-        self.assertTrue(mesh_seq.converged[0])
+        self.assertTrue(mesh_seq.check_qoi_convergence())
 
     def test_qoi_convergence_values_not_converged(self):
         mesh_seq = self.mesh_seq("end_time")
         mesh_seq.fp_iteration = mesh_seq.params.miniter
         mesh_seq.qoi_values = np.ones(mesh_seq.params.miniter + 1)
         mesh_seq.qoi_values[-1] = 100.0
-        mesh_seq.check_qoi_convergence()
-        self.assertFalse(mesh_seq.converged[0])
+        self.assertFalse(mesh_seq.check_qoi_convergence())


### PR DESCRIPTION
If `rigorous=False` then we get the existing behaviour where element, QoI, or estimator convergence implies termination of the fixed point iteration. If `rigorous=True` then all three conditions are required. Moreover, the `check_convergence` array is always `True` everywhere in rigorous mode.

This PR also changes the intermediate meaning of the `MeshSeq.converged` attribute slightly. Until convergence, it now relates specifically to whether element count has converged on each subinterval, whereas QoI and estimator convergence are summarised by single bools. If `rigorous=False` and either QoI or estimator convergence is detected, then we set `convergence[:] = True`.

Closes #53.