### PR TITLE
Remove remnant `adjoint=True` flags

### DIFF
--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -389,8 +389,8 @@ class AdjointMeshSeq(MeshSeq):
                                 )
                         elif j * stride + 1 == num_solve_blocks:
                             if i + 1 < num_subintervals:
-                                sols.adjoint_next[i][j].assign(
-                                    project(sols.adjoint_next[i + 1][0], fs[i])
+                                sols.adjoint_next[i][j].project(
+                                    sols.adjoint_next[i + 1][0], fs[i]
                                 )
                         else:
                             raise IndexError(

--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -312,7 +312,7 @@ class AdjointMeshSeq(MeshSeq):
             else:
                 for field, fs in function_spaces.items():
                     checkpoint[field].block_variable.adj_value = project(
-                        seeds[field], fs[i], adjoint=True
+                        seeds[field], fs[i]
                     )
 
             # Update adjoint solver kwargs
@@ -390,9 +390,7 @@ class AdjointMeshSeq(MeshSeq):
                         elif j * stride + 1 == num_solve_blocks:
                             if i + 1 < num_subintervals:
                                 sols.adjoint_next[i][j].assign(
-                                    project(
-                                        sols.adjoint_next[i + 1][0], fs[i], adjoint=True
-                                    )
+                                    project(sols.adjoint_next[i + 1][0], fs[i])
                                 )
                         else:
                             raise IndexError(


### PR DESCRIPTION
Closes #83.

Those flags are no longer needed because the mesh-to-mesh projection now identifies any `Cofunction` as needing to have the adjoint projection operator, whereas standard `Function`s get the standard projection operator.

This PR also drops an unnecessary assignment in one of those lines.