### PR TITLE
Store solutions and indicators

### DIFF
--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -173,35 +173,28 @@ class AdjointMeshSeq(MeshSeq):
                 )
         return solve_blocks
 
-    @property
-    def solutions(self):
-        """
-        Arrays holding exported forward and adjoint solutions and their lagged
-        counterparts, as well as the adjoint actions, if the problem is unsteady.
-        """
-        if not hasattr(self, "_solutions"):
-            P = self.time_partition
-            labels = ("forward", "forward_old", "adjoint")
-            if not self.steady:
-                labels += ("adjoint_next",)
-            self._solutions = AttrDict(
-                {
-                    field: AttrDict(
-                        {
-                            label: [
-                                [
-                                    firedrake.Function(fs, name=f"{field}_{label}")
-                                    for j in range(P.num_exports_per_subinterval[i] - 1)
-                                ]
-                                for i, fs in enumerate(self.function_spaces[field])
+    def _create_solutions(self):
+        P = self.time_partition
+        labels = ("forward", "forward_old", "adjoint")
+        if not self.steady:
+            labels += ("adjoint_next",)
+        self._solutions = AttrDict(
+            {
+                field: AttrDict(
+                    {
+                        label: [
+                            [
+                                firedrake.Function(fs, name=f"{field}_{label}")
+                                for j in range(P.num_exports_per_subinterval[i] - 1)
                             ]
-                            for label in labels
-                        }
-                    )
-                    for field in self.fields
-                }
-            )
-        return self._solutions
+                            for i, fs in enumerate(self.function_spaces[field])
+                        ]
+                        for label in labels
+                    }
+                )
+                for field in self.fields
+            }
+        )
 
     @PETSc.Log.EventDecorator()
     def solve_adjoint(

--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -214,36 +214,29 @@ class AdjointMeshSeq(MeshSeq):
         """
         Solve an adjoint problem on a sequence of subintervals.
 
-        As well as the quantity of interest value, a dictionary
-        of solution fields is computed, the contents of which
-        give values at all exported timesteps, indexed first by
-        the field label and then by type. The contents of these
-        nested dictionaries are lists which are indexed first by
-        subinterval and then by export. For a given exported
-        timestep, the solution types are:
+        As well as the quantity of interest value, a dictionary of solution fields is
+        computed, the contents of which give values at all exported timesteps, indexed
+        first by the field label and then by type. The contents of these nested
+        dictionaries are lists which are indexed first by subinterval and then by
+        export. For a given exported timestep, the solution types are:
 
-        * ``'forward'``: the forward solution after taking the
-            timestep;
-        * ``'forward_old'``: the forward solution before taking
-            the timestep
-        * ``'adjoint'``: the adjoint solution after taking the
-            timestep;
-        * ``'adjoint_next'``: the adjoint solution before taking
-            the timestep (backwards).
+        * ``'forward'``: the forward solution after taking the timestep;
+        * ``'forward_old'``: the forward solution before taking the timestep
+        * ``'adjoint'``: the adjoint solution after taking the timestep;
+        * ``'adjoint_next'``: the adjoint solution before taking the timestep
+          (backwards).
 
-        :kwarg solver_kwargs: a dictionary providing parameters
-            to the solver. Any keyword arguments for the QoI
-            should be included as a subdict with label 'qoi_kwargs'
-        :kwarg adj_solver_kwargs: a dictionary providing parameters
-            to the adjoint solver.
-        :kwarg get_adj_values: additionally output adjoint
-            actions at exported timesteps
-        :kwarg test_checkpoint_qoi: solve over the final
-            subinterval when checkpointing so that the QoI
-            value can be checked across runs
+        :kwarg solver_kwargs: a dictionary providing parameters to the solver. Any
+            keyword arguments for the QoI should be included as a subdict with label
+            'qoi_kwargs'
+        :kwarg adj_solver_kwargs: a dictionary providing parameters to the adjoint
+            solver.
+        :kwarg get_adj_values: additionally output adjoint actions at exported timesteps
+        :kwarg test_checkpoint_qoi: solve over the final subinterval when checkpointing
+            so that the QoI value can be checked across runs
 
-        :return solution: an :class:`~.AttrDict` containing
-            solution fields and their lagged versions.
+        :return solution: an :class:`~.AttrDict` containing solution fields and their
+            lagged versions. This can also be accessed as :meth:`solutions`.
         """
         P = self.time_partition
         num_subintervals = len(self)

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -293,6 +293,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
                 update_params(self.params, self.fp_iteration)
 
             # Indicate errors over all meshes
+            self._create_solutions()
             _, indicators = self.indicate_errors(
                 enrichment_kwargs=enrichment_kwargs,
                 adj_kwargs=adj_kwargs,

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -213,7 +213,9 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
                 )
             assert not isinstance(by_field, Function) and isinstance(by_field, Iterable)
             for by_mesh, dt in zip(by_field, self.time_partition.timesteps):
-                assert not isinstance(by_mesh, Function) and isinstance(by_mesh, Iterable)
+                assert not isinstance(by_mesh, Function) and isinstance(
+                    by_mesh, Iterable
+                )
                 for indicator in by_mesh:
                     if absolute_value:
                         indicator.interpolate(abs(indicator))

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -132,7 +132,6 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
         for i, mesh in enumerate(self):
             # Get Functions
             u, u_, u_star, u_star_next, u_star_e = {}, {}, {}, {}, {}
-            # solutions = {}
             enriched_spaces = {f: mesh_seq_e.function_spaces[f][i] for f in self.fields}
             mapping = {}
             for f, fs_e in enriched_spaces.items():
@@ -142,14 +141,6 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
                 u_star[f] = Function(fs_e)
                 u_star_next[f] = Function(fs_e)
                 u_star_e[f] = Function(fs_e)
-                # solutions[f] = [
-                #     self.solutions[f][FWD][i],
-                #     self.solutions[f][FWD_OLD][i],
-                #     self.solutions[f][ADJ][i],
-                #     self.solutions[f][ADJ_NEXT][i],
-                #     mesh_seq_e.solutions[f][ADJ][i],
-                #     mesh_seq_e.solutions[f][ADJ_NEXT][i],
-                # ]
 
             # Get forms for each equation in enriched space
             forms = mesh_seq_e.form(i, mapping)

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -485,31 +485,34 @@ class MeshSeq:
                 " dependencies."
             )
 
+    def _create_solutions(self):
+        P = self.time_partition
+        labels = ("forward", "forward_old")
+        self._solutions = AttrDict(
+            {
+                field: AttrDict(
+                    {
+                        label: [
+                            [
+                                firedrake.Function(fs, name=f"{field}_{label}")
+                                for j in range(P.num_exports_per_subinterval[i] - 1)
+                            ]
+                            for i, fs in enumerate(self.function_spaces[field])
+                        ]
+                        for label in labels
+                    }
+                )
+                for field in self.fields
+            }
+        )
+
     @property
     def solutions(self):
         """
-        Arrays holding exported forward solutions and their lagged counterparts.
+        Arrays holding exported solution fields and their lagged counterparts.
         """
         if not hasattr(self, "_solutions"):
-            P = self.time_partition
-            labels = ("forward", "forward_old")
-            self._solutions = AttrDict(
-                {
-                    field: AttrDict(
-                        {
-                            label: [
-                                [
-                                    firedrake.Function(fs, name=f"{field}_{label}")
-                                    for j in range(P.num_exports_per_subinterval[i] - 1)
-                                ]
-                                for i, fs in enumerate(self.function_spaces[field])
-                            ]
-                            for label in labels
-                        }
-                    )
-                    for field in self.fields
-                }
-            )
+            self._create_solutions()
         return self._solutions
 
     @PETSc.Log.EventDecorator()

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -523,17 +523,15 @@ class MeshSeq:
         first by subinterval and then by export. For a given exported timestep, the
         solution types are:
 
-        * ``'forward'``: the forward solution after taking the
-            timestep;
-        * ``'forward_old'``: the forward solution before taking
-            the timestep.
+        * ``'forward'``: the forward solution after taking the timestep;
+        * ``'forward_old'``: the forward solution before taking the timestep.
 
         :kwarg solver_kwargs: a dictionary providing parameters to the solver. Any
             keyword arguments for the QoI should be included as a subdict with label
             'qoi_kwargs'
 
         :return solution: an :class:`~.AttrDict` containing solution fields and their
-            lagged versions.
+            lagged versions. This can also be accessed as :meth:`solutions`.
         """
         num_subintervals = len(self)
         P = self.time_partition

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -678,10 +678,11 @@ class MeshSeq:
                 update_params(self.params, self.fp_iteration)
 
             # Solve the forward problem over all meshes
-            sols = self.solve_forward(solver_kwargs=solver_kwargs)
+            self._create_solutions()
+            self.solve_forward(solver_kwargs=solver_kwargs)
 
             # Adapt meshes, logging element and vertex counts
-            continue_unconditionally = adaptor(self, sols)
+            continue_unconditionally = adaptor(self, self.solutions)
             if self.params.drop_out_converged:
                 self.check_convergence[:] = np.logical_not(
                     np.logical_or(continue_unconditionally, self.converged)
@@ -701,4 +702,4 @@ class MeshSeq:
                         f" {self.params.maxiter} iterations."
                     )
 
-        return sols
+        return self.solutions

--- a/test/test_error_estimation.py
+++ b/test/test_error_estimation.py
@@ -105,13 +105,17 @@ class TestIndicators2Estimator(ErrorEstimationTestCase):
         self.assertAlmostEqual(estimator, 0.5)  # 0.5 * (0.5 + 0.5)
 
     def test_time_partition_same_timestep(self):
-        mesh_seq = self.mesh_seq(time_partition=TimePartition(1.0, 2, [0.5, 0.5], ["field"]))
+        mesh_seq = self.mesh_seq(
+            time_partition=TimePartition(1.0, 2, [0.5, 0.5], ["field"])
+        )
         mesh_seq._indicators = {"field": [[form2indicator(2 * self.one * dx)]]}
         estimator = mesh_seq.error_estimate()
         self.assertAlmostEqual(estimator, 1)  # 2 * 0.5 * (0.5 + 0.5)
 
     def test_time_partition_different_timesteps(self):
-        mesh_seq = self.mesh_seq(time_partition=TimePartition(1.0, 2, [0.5, 0.25], ["field"]))
+        mesh_seq = self.mesh_seq(
+            time_partition=TimePartition(1.0, 2, [0.5, 0.25], ["field"])
+        )
         indicator = form2indicator(self.one * dx)
         mesh_seq._indicators = {"field": [[indicator], 2 * [indicator]]}
         estimator = mesh_seq.error_estimate()
@@ -120,7 +124,9 @@ class TestIndicators2Estimator(ErrorEstimationTestCase):
         )  # 0.5 * (0.5 + 0.5) + 0.25 * 2 * (0.5 + 0.5)
 
     def test_time_instant_multiple_fields(self):
-        mesh_seq = self.mesh_seq(time_partition=TimeInstant(["field1", "field2"], time=1.0))
+        mesh_seq = self.mesh_seq(
+            time_partition=TimeInstant(["field1", "field2"], time=1.0)
+        )
         indicator = form2indicator(self.one * dx)
         mesh_seq._indicators = {"field1": [[indicator]], "field2": [[indicator]]}
         estimator = mesh_seq.error_estimate()

--- a/test/test_error_estimation.py
+++ b/test/test_error_estimation.py
@@ -56,7 +56,7 @@ class TestForm2Indicator(ErrorEstimationTestCase):
 
 class TestIndicators2Estimator(ErrorEstimationTestCase):
     """
-    Unit tests for :func:`indicators2estimator`.
+    Unit tests for :meth:`error_estimate`.
     """
 
     def mesh_seq(self, time_partition=None):
@@ -67,92 +67,54 @@ class TestIndicators2Estimator(ErrorEstimationTestCase):
             qoi_type="steady" if num_timesteps == 1 else "end_time",
         )
 
-    def test_indicators_type_error1(self):
-        with self.assertRaises(TypeError) as cm:
-            self.mesh_seq().indicators2estimator(self.one)
-        msg = (
-            "Expected 'indicators' to be a dict, not"
-            " '<class 'firedrake.function.Function'>'."
-        )
-        self.assertEqual(str(cm.exception), msg)
-
-    def test_indicators_type_error2(self):
-        with self.assertRaises(TypeError) as cm:
-            self.mesh_seq().indicators2estimator({"field": self.one})
-        msg = (
-            "Expected values of 'indicators' to be iterables, not"
-            " '<class 'firedrake.function.Function'>'."
-        )
-        self.assertEqual(str(cm.exception), msg)
-
-    def test_indicators_type_error3(self):
-        with self.assertRaises(TypeError) as cm:
-            self.mesh_seq().indicators2estimator({"field": 1})
-        msg = "Expected values of 'indicators' to be iterables, not '<class 'int'>'."
-        self.assertEqual(str(cm.exception), msg)
-
-    def test_indicators_type_error4(self):
-        with self.assertRaises(TypeError) as cm:
-            self.mesh_seq().indicators2estimator({"field": [self.one]})
-        msg = (
-            "Expected entries of 'indicators' to be iterables, not"
-            " '<class 'firedrake.function.Function'>'."
-        )
-        self.assertEqual(str(cm.exception), msg)
-
-    def test_indicators_type_error5(self):
-        with self.assertRaises(TypeError) as cm:
-            self.mesh_seq().indicators2estimator({"field": [1]})
-        msg = "Expected entries of 'indicators' to be iterables, not '<class 'int'>'."
-        self.assertEqual(str(cm.exception), msg)
-
     def test_time_partition_wrong_field_error(self):
+        mesh_seq = self.mesh_seq()
+        mesh_seq._indicators = {"f": [[self.one]]}
         with self.assertRaises(ValueError) as cm:
-            self.mesh_seq().indicators2estimator({"f": [[self.one]]})
+            mesh_seq.error_estimate()
         msg = "Key 'f' does not exist in the TimePartition provided."
         self.assertEqual(str(cm.exception), msg)
 
     def test_absolute_value_type_error(self):
+        mesh_seq = self.mesh_seq()
+        mesh_seq._indicators = {"field": [[self.one]]}
         with self.assertRaises(TypeError) as cm:
-            self.mesh_seq().indicators2estimator(
-                {"field": [[self.one]]}, absolute_value=0
-            )
+            mesh_seq.error_estimate(absolute_value=0)
         msg = "Expected 'absolute_value' to be a bool, not '<class 'int'>'."
         self.assertEqual(str(cm.exception), msg)
 
     def test_unit_time_instant(self):
         mesh_seq = self.mesh_seq(time_partition=TimeInstant("field", time=1.0))
-        indicator = form2indicator(self.one * dx)
-        estimator = mesh_seq.indicators2estimator({"field": [[indicator]]})
+        mesh_seq._indicators = {"field": [[form2indicator(self.one * dx)]]}
+        estimator = mesh_seq.error_estimate()
         self.assertAlmostEqual(estimator, 1)  # 1 * (0.5 + 0.5)
 
     @parameterized.expand([[False], [True]])
     def test_unit_time_instant_abs(self, absolute_value):
         mesh_seq = self.mesh_seq(time_partition=TimeInstant("field", time=1.0))
-        indicator = form2indicator(-self.one * dx)
-        estimator = mesh_seq.indicators2estimator(
-            {"field": [[indicator]]}, absolute_value=absolute_value
-        )
+        mesh_seq._indicators = {"field": [[form2indicator(-self.one * dx)]]}
+        estimator = mesh_seq.error_estimate(absolute_value=absolute_value)
         self.assertAlmostEqual(
             estimator, 1 if absolute_value else -1
         )  # (-)1 * (0.5 + 0.5)
 
     def test_half_time_instant(self):
         mesh_seq = self.mesh_seq(time_partition=TimeInstant("field", time=0.5))
-        indicator = form2indicator(self.one * dx)
-        estimator = mesh_seq.indicators2estimator({"field": [[indicator]]})
+        mesh_seq._indicators = {"field": [[form2indicator(self.one * dx)]]}
+        estimator = mesh_seq.error_estimate()
         self.assertAlmostEqual(estimator, 0.5)  # 0.5 * (0.5 + 0.5)
 
     def test_time_partition_same_timestep(self):
         mesh_seq = self.mesh_seq(time_partition=TimePartition(1.0, 2, [0.5, 0.5], ["field"]))
-        indicator = form2indicator(self.one * dx)
-        estimator = mesh_seq.indicators2estimator({"field": [2 * [indicator]]})
+        mesh_seq._indicators = {"field": [[form2indicator(2 * self.one * dx)]]}
+        estimator = mesh_seq.error_estimate()
         self.assertAlmostEqual(estimator, 1)  # 2 * 0.5 * (0.5 + 0.5)
 
     def test_time_partition_different_timesteps(self):
         mesh_seq = self.mesh_seq(time_partition=TimePartition(1.0, 2, [0.5, 0.25], ["field"]))
         indicator = form2indicator(self.one * dx)
-        estimator = mesh_seq.indicators2estimator({"field": [[indicator], 2 * [indicator]]})
+        mesh_seq._indicators = {"field": [[indicator], 2 * [indicator]]}
+        estimator = mesh_seq.error_estimate()
         self.assertAlmostEqual(
             estimator, 1
         )  # 0.5 * (0.5 + 0.5) + 0.25 * 2 * (0.5 + 0.5)
@@ -160,7 +122,8 @@ class TestIndicators2Estimator(ErrorEstimationTestCase):
     def test_time_instant_multiple_fields(self):
         mesh_seq = self.mesh_seq(time_partition=TimeInstant(["field1", "field2"], time=1.0))
         indicator = form2indicator(self.one * dx)
-        estimator = mesh_seq.indicators2estimator({"field1": [[indicator]], "field2": [[indicator]]})
+        mesh_seq._indicators = {"field1": [[indicator]], "field2": [[indicator]]}
+        estimator = mesh_seq.error_estimate()
         self.assertAlmostEqual(estimator, 2)  # 2 * (1 * (0.5 + 0.5))
 
 

--- a/test_adjoint/test_fp_iteration.py
+++ b/test_adjoint/test_fp_iteration.py
@@ -244,7 +244,7 @@ class TestGoalOrientedMeshSeq(TestAdjointMeshSeq):
             time_partition=TimePartition(1.0, 1, 0.5, []),
             get_qoi=constant_qoi,
         )
-        mesh_seq.indicators2estimator = MagicMock(return_value=1)
+        mesh_seq.error_estimate = MagicMock(return_value=1)
         mesh_seq.fixed_point_iteration(empty_adaptor)
         self.assertTrue(np.allclose(mesh_seq.element_counts, 1))
         self.assertTrue(np.allclose(mesh_seq.converged, True))


### PR DESCRIPTION
Closes #74. Progress towards #55.

This PR simplifies things by storing solution fields and error indicators on the `MeshSeq`. Note that they get overwritten each iteration of the FPE, though.

The PR also simplifies and renames `indicators2estimator` as `error_estimate`.