### PR TITLE
Automatically install pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
 # Directories
-bench/
-build/
-data/
-docs/source/demos/
 htmlcov*
 outputs/
 plots/
@@ -11,7 +7,6 @@ goalie.egg-info/
 
 # Specific files
 .coverage
-docs/source/goalie.rst
 
 # File extensions
 *.ipynb*

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,6 @@ demo:
 	@cd demos && make
 	@echo "Done."
 
-doc: demo
-	@echo "Building docs in html format..."
-	@cd docs && make html
-	@echo "Done."
-
 tree:
 	@tree -d .
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install:
 
 lint:
 	@echo "Checking lint..."
-	@flake8 --ignore=E501,E226,E402,E741,F403,F405,W503
+	@flake8
 	@echo "PASS"
 
 test: lint

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ install:
 	@echo "Installing Goalie..."
 	@python3 -m pip install -e .
 	@echo "Done."
+	@echo "Setting up pre-commit..."
+	@pre-commit install
+	@echo "Done."
 
 lint:
 	@echo "Checking lint..."

--- a/demos/burgers-hessian.py
+++ b/demos/burgers-hessian.py
@@ -84,7 +84,11 @@ dt = 1 / n
 
 num_subintervals = len(meshes)
 time_partition = TimePartition(
-    end_time, num_subintervals, dt, fields, num_timesteps_per_export=2,
+    end_time,
+    num_subintervals,
+    dt,
+    fields,
+    num_timesteps_per_export=2,
 )
 
 params = MetricParameters(
@@ -167,7 +171,9 @@ def adaptor(mesh_seq, solutions):
     num_dofs = mesh_seq.count_vertices()
     num_elem = mesh_seq.count_elements()
     pyrint(f"fixed point iteration {iteration + 1}:")
-    for i, (complexity, ndofs, nelem) in enumerate(zip(complexities, num_dofs, num_elem)):
+    for i, (complexity, ndofs, nelem) in enumerate(
+        zip(complexities, num_dofs, num_elem)
+    ):
         pyrint(
             f"  subinterval {i}, complexity: {complexity:4.0f}"
             f", dofs: {ndofs:4d}, elements: {nelem:4d}"

--- a/demos/burgers2.py
+++ b/demos/burgers2.py
@@ -99,7 +99,11 @@ dt = 1 / n
 
 num_subintervals = len(meshes)
 time_partition = TimePartition(
-    end_time, num_subintervals, dt, fields, num_timesteps_per_export=2,
+    end_time,
+    num_subintervals,
+    dt,
+    fields,
+    num_timesteps_per_export=2,
 )
 mesh_seq = AdjointMeshSeq(
     time_partition,

--- a/demos/burgers_ee.py
+++ b/demos/burgers_ee.py
@@ -109,7 +109,11 @@ end_time = 0.5
 dt = 1 / n
 num_subintervals = len(meshes)
 time_partition = TimePartition(
-    end_time, num_subintervals, dt, fields, num_timesteps_per_export=2,
+    end_time,
+    num_subintervals,
+    dt,
+    fields,
+    num_timesteps_per_export=2,
 )
 
 # A key difference between this demo and the previous ones is that we need to

--- a/demos/time_partition.py
+++ b/demos/time_partition.py
@@ -97,7 +97,9 @@ P = TimePartition(end_time, num_subintervals, dt, fields, num_timesteps_per_expo
 # This can be remedied by also setting
 # ``num_timesteps_per_export`` as a list. ::
 
-P = TimePartition(end_time, num_subintervals, dt, fields, num_timesteps_per_export=[2, 4])
+P = TimePartition(
+    end_time, num_subintervals, dt, fields, num_timesteps_per_export=[2, 4]
+)
 
 # So far, we have assumed that the subintervals
 # are of uniform length. This need not be the case.

--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -382,7 +382,9 @@ class AdjointMeshSeq(MeshSeq):
                                 )
                         elif j * stride + 1 == num_solve_blocks:
                             if i + 1 < num_subintervals:
-                                sols.adjoint_next[i][j].project(sols.adjoint_next[i + 1][0])
+                                sols.adjoint_next[i][j].project(
+                                    sols.adjoint_next[i + 1][0]
+                                )
                         else:
                             raise IndexError(
                                 "Cannot extract solve block"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+black
 coverage
+flake8
 parameterized
 pre-commit


### PR DESCRIPTION
Closes #94.

Installed pre-commit hooks are called every time you commit to the repo. In this case, we hook up flake8 and Black so that the code is automatically formatted at each commit. This ensures consistency and removes any need for future reformatting.