### PR TITLE
#98: Add adaptor_kwargs to fixed point iteration

### DIFF
--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -250,6 +250,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
         self,
         adaptor: Callable,
         enrichment_kwargs: dict = {},
+        adaptor_kwargs: dict = {},
         adj_kwargs: dict = {},
         indicator_fn: Callable = get_dwr_indicator,
         **kwargs,
@@ -267,6 +268,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             iteration number
         :kwarg enrichment_kwargs: keyword arguments to pass to the global enrichment
             method
+        :kwarg adaptor_kwargs: a dictionary providing parameters to the adaptor
         :kwarg adj_kwargs: keyword arguments to pass to the adjoint solver
         :kwarg indicator_fn: function for error indication, which takes the form, adjoint
             error and enriched space(s) as arguments
@@ -310,7 +312,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
                 break
 
             # Adapt meshes and log element counts
-            continue_unconditionally = adaptor(self, self.solutions, self.indicators)
+            continue_unconditionally = adaptor(self, self.solutions, self.indicators, **adaptor_kwargs)
             if self.params.drop_out_converged:
                 self.check_convergence[:] = np.logical_not(
                     np.logical_or(continue_unconditionally, self.converged)

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -652,7 +652,7 @@ class MeshSeq:
 
     @PETSc.Log.EventDecorator()
     def fixed_point_iteration(
-        self, adaptor: Callable, solver_kwargs: dict = {}, **kwargs
+        self, adaptor: Callable, solver_kwargs: dict = {}, adaptor_kwargs: dict = {}, **kwargs
     ):
         r"""
         Apply goal-oriented mesh adaptation using a fixed point iteration loop.
@@ -666,6 +666,7 @@ class MeshSeq:
             iteration. Its arguments are the parameter class and the fixed point
             iteration
         :kwarg solver_kwargs: a dictionary providing parameters to the solver
+        :kwarg adaptor_kwargs: a dictionary providing parameters to the adaptor
         """
         update_params = kwargs.get("update_params")
         self.element_counts = [self.count_elements()]
@@ -682,7 +683,7 @@ class MeshSeq:
             self.solve_forward(solver_kwargs=solver_kwargs)
 
             # Adapt meshes, logging element and vertex counts
-            continue_unconditionally = adaptor(self, self.solutions)
+            continue_unconditionally = adaptor(self, self.solutions, **adaptor_kwargs)
             if self.params.drop_out_converged:
                 self.check_convergence[:] = np.logical_not(
                     np.logical_or(continue_unconditionally, self.converged)


### PR DESCRIPTION
Closes #98.

Small pull request to allow kwargs to be passed to the `adaptor` function in `fixed_point_iteration`. I am not 100% convinced myself how useful this is, as I suggested it for purely aesthetic purposes - e.g. if we have the `adaptor` function defined in a different script. But even then a similar thing may be achieved with factory pattern, for example, with the current goalie code. So feel free to reject this @jwallwork23 if you'd prefer not to change the goalie code for this!