### PR TITLE
107 mixed space adj project

### DIFF
--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -1,6 +1,7 @@
 """
 Drivers for solving adjoint problems on sequences of meshes.
 """
+
 import firedrake
 from firedrake.petsc import PETSc
 from firedrake.adjoint import pyadjoint
@@ -382,8 +383,8 @@ class AdjointMeshSeq(MeshSeq):
                                 )
                         elif j * stride + 1 == num_solve_blocks:
                             if i + 1 < num_subintervals:
-                                sols.adjoint_next[i][j].project(
-                                    sols.adjoint_next[i + 1][0]
+                                project(
+                                    sols.adjoint_next[i + 1][0], sols.adjoint_next[i][j]
                                 )
                         else:
                             raise IndexError(

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -1,6 +1,7 @@
 """
 Drivers for goal-oriented error estimation on sequences of meshes.
 """
+
 from .adjoint import AdjointMeshSeq
 from .error_estimation import get_dwr_indicator
 from .log import pyrint
@@ -61,7 +62,11 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             get_qoi=self._get_qoi,
             get_bcs=self._get_bcs,
             qoi_type=self.qoi_type,
+            parameters=self.params,
         )
+
+        # update self._fs variable for enriched mesh
+        mesh_seq_e.function_spaces
 
         # Apply p-refinement
         if enrichment_method == "p":
@@ -312,7 +317,9 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
                 break
 
             # Adapt meshes and log element counts
-            continue_unconditionally = adaptor(self, self.solutions, self.indicators, **adaptor_kwargs)
+            continue_unconditionally = adaptor(
+                self, self.solutions, self.indicators, **adaptor_kwargs
+            )
             if self.params.drop_out_converged:
                 self.check_convergence[:] = np.logical_not(
                     np.logical_or(continue_unconditionally, self.converged)

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -65,8 +65,8 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             parameters=self.params,
         )
 
-        # update self._fs variable for enriched mesh
-        mesh_seq_e.function_spaces
+        # Update function spaces for enriched mesh
+        mesh_seq_e.update_function_spaces
 
         # Apply p-refinement
         if enrichment_method == "p":

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -64,9 +64,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             qoi_type=self.qoi_type,
             parameters=self.params,
         )
-
-        # Update function spaces for enriched mesh
-        mesh_seq_e.update_function_spaces
+        mesh_seq_e.update_function_spaces()
 
         # Apply p-refinement
         if enrichment_method == "p":

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -1,6 +1,7 @@
 """
 Sequences of meshes corresponding to a :class:`~.TimePartition`.
 """
+
 import firedrake
 from firedrake.petsc import PETSc
 from firedrake.adjoint_utils.solving import get_solve_blocks
@@ -248,6 +249,14 @@ class MeshSeq:
             self._function_spaces_consistent
         ), "Meshes and function spaces are inconsistent"
         return self._fs
+
+    @property
+    def update_function_spaces(self):
+        """
+        Update the function space dictionary associated with the :class:`MeshSeq`
+        """
+        if self._fs is None:
+            self.function_spaces
 
     @property
     def initial_condition(self) -> AttrDict:
@@ -652,7 +661,11 @@ class MeshSeq:
 
     @PETSc.Log.EventDecorator()
     def fixed_point_iteration(
-        self, adaptor: Callable, solver_kwargs: dict = {}, adaptor_kwargs: dict = {}, **kwargs
+        self,
+        adaptor: Callable,
+        solver_kwargs: dict = {},
+        adaptor_kwargs: dict = {},
+        **kwargs,
     ):
         r"""
         Apply goal-oriented mesh adaptation using a fixed point iteration loop.

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -235,8 +235,10 @@ class MeshSeq:
             )
         return consistent
 
-    @property
-    def function_spaces(self) -> list:
+    def update_function_spaces(self) -> list:
+        """
+        Update the function space dictionary associated with the :class:`MeshSeq`.
+        """
         if self._fs is None or not self._function_spaces_consistent:
             self._fs = [self.get_function_spaces(mesh) for mesh in self.meshes]
             self._fs = AttrDict(
@@ -251,12 +253,8 @@ class MeshSeq:
         return self._fs
 
     @property
-    def update_function_spaces(self):
-        """
-        Update the function space dictionary associated with the :class:`MeshSeq`
-        """
-        if self._fs is None:
-            self.function_spaces
+    def function_spaces(self):
+        return self.update_function_spaces()
 
     @property
     def initial_condition(self) -> AttrDict:


### PR DESCRIPTION
fixes #107 
Calls the override `project` function instead of the default Firedrake function to deal with mixed function spaces and adjoints.

Additionally, modifies the creation of the enriched mesh to:
- pass inherited parameters correctly in the constructor
- force population of `self._fs` variable required for mesh-to-mesh conservative transfer
