### PR TITLE
Introduce indexing and slicing of `TimePartition`

### DIFF
--- a/demos/burgers_oo.py
+++ b/demos/burgers_oo.py
@@ -87,7 +87,7 @@ class BurgersMeshSeq(GoalOrientedMeshSeq):
     @annotate_qoi
     def get_qoi(self, solutions, i):
         R = FunctionSpace(self[i], "R", 0)
-        dt = Function(R).assign(self.time_partition[i].timestep)
+        dt = Function(R).assign(self.time_partition.timesteps[i])
 
         def end_time_qoi():
             u = solutions["u"]

--- a/demos/burgers_time_integrated.py
+++ b/demos/burgers_time_integrated.py
@@ -100,7 +100,7 @@ def get_solver(mesh_seq):
 
 def get_qoi(mesh_seq, solutions, i):
     R = FunctionSpace(mesh_seq[i], "R", 0)
-    dt = Function(R).assign(mesh_seq.time_partition[i].timestep)
+    dt = Function(R).assign(mesh_seq.time_partition.timesteps[i])
 
     def time_integrated_qoi(t):
         u = solutions["u"]

--- a/demos/gray_scott.py
+++ b/demos/gray_scott.py
@@ -58,7 +58,7 @@ def get_form(mesh_seq):
 
         # Define constants
         R = FunctionSpace(mesh_seq[index], "R", 0)
-        dt = Function(R).assign(mesh_seq.time_partition[index].timestep)
+        dt = Function(R).assign(mesh_seq.time_partition.timesteps[index])
         D_a = Function(R).assign(8.0e-05)
         D_b = Function(R).assign(4.0e-05)
         gamma = Function(R).assign(0.024)

--- a/demos/gray_scott_split.py
+++ b/demos/gray_scott_split.py
@@ -58,7 +58,7 @@ def get_form(mesh_seq):
 
         # Define constants
         R = FunctionSpace(mesh_seq[index], "R", 0)
-        dt = Function(R).assign(mesh_seq.time_partition[index].timestep)
+        dt = Function(R).assign(mesh_seq.time_partition.timesteps[index])
         D_a = Function(R).assign(8.0e-05)
         D_b = Function(R).assign(4.0e-05)
         gamma = Function(R).assign(0.024)

--- a/demos/solid_body_rotation.py
+++ b/demos/solid_body_rotation.py
@@ -158,7 +158,7 @@ def get_form(mesh_seq):
 
         # Define constants
         R = FunctionSpace(mesh_seq[index], "R", 0)
-        dt = Function(R).assign(mesh_seq.time_partition[index].timestep)
+        dt = Function(R).assign(mesh_seq.time_partition.timesteps[index])
         theta = Function(R).assign(0.5)
 
         psi = TrialFunction(V)

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -381,7 +381,7 @@ class MeshSeq:
                 )
 
         # Check that the number of timesteps does not exceed the number of solve blocks
-        num_timesteps = self.time_partition[subinterval].num_timesteps
+        num_timesteps = self.time_partition.num_timesteps_per_subinterval[subinterval]
         if num_timesteps > N:
             raise ValueError(
                 f"Number of timesteps exceeds number of solve blocks for field '{field}'"
@@ -653,7 +653,11 @@ class MeshSeq:
 
     @PETSc.Log.EventDecorator()
     def fixed_point_iteration(
-        self, adaptor: Callable, solver_kwargs: dict = {}, adaptor_kwargs: dict = {}, **kwargs
+        self,
+        adaptor: Callable,
+        solver_kwargs: dict = {},
+        adaptor_kwargs: dict = {},
+        **kwargs,
     ):
         r"""
         Apply goal-oriented mesh adaptation using a fixed point iteration loop.

--- a/goalie/time_partition.py
+++ b/goalie/time_partition.py
@@ -2,7 +2,6 @@
 Partitioning for the temporal domain.
 """
 from .log import debug
-from .utility import AttrDict
 from collections.abc import Iterable
 import numpy as np
 from typing import List, Optional, Union
@@ -157,17 +156,15 @@ class TimePartition:
         :return: subinterval bounds and timestep
             associated with that index
         """
-        return AttrDict(
-            {
-                "subinterval": self.subintervals[i],
-                "timestep": self.timesteps[i],
-                "num_timesteps_per_export": self.num_timesteps_per_export[i],
-                "num_exports": self.num_exports_per_subinterval[i],
-                "num_timesteps": self.num_timesteps_per_subinterval[i],
-                "start_time": self.subintervals[i][0],
-                "end_time": self.subintervals[i][1],
-                "length": self.subintervals[i][1] - self.subintervals[i][0],
-            }
+        return TimePartition(
+            end_time=self.subintervals[i][1],
+            num_subintervals=1,
+            timesteps=self.timesteps[i],
+            fields=self.fields,
+            num_timesteps_per_export=self.num_timesteps_per_export[i],
+            start_time=self.subintervals[i][0],
+            subintervals=self.subintervals[i],
+            field_types=self.field_types,
         )
 
     @property

--- a/goalie/time_partition.py
+++ b/goalie/time_partition.py
@@ -153,8 +153,7 @@ class TimePartition:
     def __getitem__(self, i: int) -> dict:
         """
         :arg i: index
-        :return: subinterval bounds and timestep
-            associated with that index
+        :return: subinterval bounds and timestep associated with that index
         """
         return TimePartition(
             end_time=self.subintervals[i][1],
@@ -163,7 +162,6 @@ class TimePartition:
             fields=self.fields,
             num_timesteps_per_export=self.num_timesteps_per_export[i],
             start_time=self.subintervals[i][0],
-            subintervals=self.subintervals[i],
             field_types=self.field_types,
         )
 

--- a/goalie/time_partition.py
+++ b/goalie/time_partition.py
@@ -150,18 +150,26 @@ class TimePartition:
     def __len__(self) -> int:
         return self.num_subintervals
 
-    def __getitem__(self, i: int) -> dict:
+    def __getitem__(self, sl: Union[int, slice]) -> dict:
         """
-        :arg i: index
+        :arg sl: index or slice
         :return: subinterval bounds and timestep associated with that index
         """
+        if not isinstance(sl, slice):
+            sl = slice(sl, sl + 1, 1)
+        step = sl.step or 1
+        if step != 1:
+            raise NotImplementedError(
+                "Can only currently handle slices with step size 1."
+            )
+        num_subintervals = len(range(sl.start, sl.stop, step))
         return TimePartition(
-            end_time=self.subintervals[i][1],
-            num_subintervals=1,
-            timesteps=self.timesteps[i],
+            end_time=self.subintervals[sl.stop - 1][1],
+            num_subintervals=num_subintervals,
+            timesteps=self.timesteps[sl],
             fields=self.fields,
-            num_timesteps_per_export=self.num_timesteps_per_export[i],
-            start_time=self.subintervals[i][0],
+            num_timesteps_per_export=self.num_timesteps_per_export[sl],
+            start_time=self.subintervals[sl.start][0],
             field_types=self.field_types,
         )
 

--- a/test/test_time_partition.py
+++ b/test/test_time_partition.py
@@ -258,5 +258,38 @@ class TestStringFormatting(unittest.TestCase):
         self.assertEqual(repr(time_instant), expected)
 
 
+class TestIndexing(unittest.TestCase):
+    r"""
+    Unit tests for indexing :class:`~.TimePartition`\s.
+    """
+
+    def setUp(self):
+        self.end_time = 1.0
+        self.fields = ["field"]
+
+    def test_time_interval(self):
+        time_interval = TimeInterval(self.end_time, [0.5], self.fields)
+        self.assertEqual(time_interval, time_interval[0])
+
+    def test_time_instant(self):
+        time_instant = TimeInstant(self.fields, time=self.end_time)
+        self.assertEqual(time_instant, time_instant[0])
+
+    def test_time_partition(self):
+        timesteps = [0.5, 0.25]
+        time_partition = TimePartition(self.end_time, 2, timesteps, self.fields)
+        tp0, tp1 = time_partition
+        self.assertEqual(len(tp0), 1)
+        self.assertEqual(len(tp1), 1)
+        self.assertAlmostEqual(tp0.start_time, 0.0)
+        self.assertAlmostEqual(tp0.end_time, 0.5)
+        self.assertAlmostEqual(tp0.end_time, tp1.start_time)
+        self.assertAlmostEqual(tp1.end_time, 1.0)
+        self.assertAlmostEqual(tp0.timesteps[0], timesteps[0])
+        self.assertAlmostEqual(tp1.timesteps[0], timesteps[1])
+        self.assertEqual(tp0.fields, self.fields)
+        self.assertEqual(tp0.fields, tp1.fields)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_time_partition.py
+++ b/test/test_time_partition.py
@@ -291,5 +291,45 @@ class TestIndexing(unittest.TestCase):
         self.assertEqual(tp0.fields, tp1.fields)
 
 
+class TestSlicing(unittest.TestCase):
+    r"""
+    Unit tests for slicing :class:`~.TimePartition`\s.
+    """
+
+    def setUp(self):
+        self.end_time = 1.0
+        self.fields = ["field"]
+
+    def test_time_interval(self):
+        time_interval = TimeInterval(self.end_time, [0.5], self.fields)
+        self.assertEqual(time_interval, time_interval[0:1])
+
+    def test_time_instant(self):
+        time_instant = TimeInstant(self.fields, time=self.end_time)
+        self.assertEqual(time_instant, time_instant[0:1])
+
+    def test_time_partition(self):
+        timesteps = [0.5, 0.25]
+        time_partition = TimePartition(self.end_time, 2, timesteps, self.fields)
+        self.assertEqual(time_partition, time_partition[0:2])
+
+    def test_time_partition_slice(self):
+        end_time = 0.75
+        timesteps = [0.25, 0.05, 0.01]
+        time_partition = TimePartition(end_time, 3, timesteps, self.fields)
+        tp0 = time_partition[0]
+        tp12 = time_partition[1:3]
+        self.assertEqual(len(tp0), 1)
+        self.assertEqual(len(tp12), 2)
+        self.assertAlmostEqual(tp0.start_time, 0.0)
+        self.assertAlmostEqual(tp0.end_time, 0.25)
+        self.assertAlmostEqual(tp0.end_time, tp12.start_time)
+        self.assertAlmostEqual(tp12.end_time, end_time)
+        self.assertAlmostEqual(tp0.timesteps[0], timesteps[0])
+        self.assertAlmostEqual(tp12.timesteps, timesteps[1:3])
+        self.assertEqual(tp0.fields, self.fields)
+        self.assertEqual(tp0.fields, tp12.fields)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_time_partition.py
+++ b/test/test_time_partition.py
@@ -267,6 +267,14 @@ class TestIndexing(unittest.TestCase):
         self.end_time = 1.0
         self.fields = ["field"]
 
+    def test_invalid_step(self):
+        timesteps = [0.5, 0.25]
+        time_partition = TimePartition(self.end_time, 2, timesteps, self.fields)
+        with self.assertRaises(NotImplementedError) as cm:
+            time_partition[::2]
+        msg = "Can only currently handle slices with step size 1."
+        self.assertEqual(str(cm.exception), msg)
+
     def test_time_interval(self):
         time_interval = TimeInterval(self.end_time, [0.5], self.fields)
         self.assertEqual(time_interval, time_interval[0])

--- a/test_adjoint/examples/burgers.py
+++ b/test_adjoint/examples/burgers.py
@@ -1,10 +1,7 @@
 """
-Problem specification for a simple Burgers
-equation test case.
+Problem specification for a simple Burgers equation test case.
 
-The test case is notable for Goalie
-because the prognostic equation is
-nonlinear.
+The test case is notable for Goalie because the prognostic equation is nonlinear.
 
 Code here is based on that found at
     https://firedrakeproject.org/demos/burgers.py.html
@@ -37,7 +34,7 @@ def get_form(self):
 
     def form(i, sols):
         u, u_ = sols["uv_2d"]
-        dt = self.time_partition[i].timestep
+        dt = self.time_partition.timesteps[i]
         fs = self.function_spaces["uv_2d"][i]
         R = FunctionSpace(self[i], "R", 0)
         dtc = Function(R).assign(dt)
@@ -55,14 +52,12 @@ def get_form(self):
 
 def get_solver(self):
     """
-    Burgers equation solved using
-    a direct method and backward
-    Euler timestepping.
+    Burgers equation solved using a direct method and backward Euler timestepping.
     """
 
     def solver(i, ic):
-        t_start, t_end = self.time_partition[i].subinterval
-        dt = self.time_partition[i].timestep
+        t_start, t_end = self.time_partition.subintervals[i]
+        dt = self.time_partition.timesteps[i]
         fs = self.function_spaces["uv_2d"][i]
         u = Function(fs, name="uv_2d")
         solution_map = {"uv_2d": u}
@@ -90,8 +85,7 @@ def get_solver(self):
 
 def get_initial_condition(self):
     """
-    Initial condition which is
-    sinusoidal in the x-direction.
+    Initial condition which is sinusoidal in the x-direction.
     """
     init_fs = self.function_spaces["uv_2d"][0]
     x, y = SpatialCoordinate(self.meshes[0])
@@ -100,13 +94,11 @@ def get_initial_condition(self):
 
 def get_qoi(self, sol, i):
     """
-    Quantity of interest which
-    computes the square L2
-    norm over the right hand
+    Quantity of interest which computes the square :math:`L^2` norm over the right hand
     boundary.
     """
     R = FunctionSpace(self[i], "R", 0)
-    dtc = Function(R).assign(self.time_partition[i].timestep)
+    dtc = Function(R).assign(self.time_partition.timesteps[i])
 
     def time_integrated_qoi(t):
         u = sol["uv_2d"]


### PR DESCRIPTION
Closes #99.

Currently, indexing a `TimePartition` returns various pieces of information associated with that subinterval. The changes introduced in this PR are more logical, i.e., indexing gives a sub-`TimePartition`. Similarly for slicing.