### PR TITLE
Disallow h-enrichment of shallow-copied meshes

### DIFF
--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -52,7 +52,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             meshes = self.meshes
 
         # Construct object to hold enriched spaces
-        mesh_seq_e = self.__class__(
+        enriched_mesh_seq = self.__class__(
             self.time_partition,
             meshes,
             get_function_spaces=self._get_function_spaces,
@@ -64,21 +64,21 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             qoi_type=self.qoi_type,
             parameters=self.params,
         )
-        mesh_seq_e.update_function_spaces()
+        enriched_mesh_seq.update_function_spaces()
 
         # Apply p-refinement
         if enrichment_method == "p":
-            for label, fs in mesh_seq_e.function_spaces.items():
+            for label, fs in enriched_mesh_seq.function_spaces.items():
                 for n, _space in enumerate(fs):
                     element = _space.ufl_element()
                     element = element.reconstruct(
                         degree=element.degree() + num_enrichments
                     )
-                    mesh_seq_e._fs[label][n] = FunctionSpace(
-                        mesh_seq_e.meshes[n], element
+                    enriched_mesh_seq._fs[label][n] = FunctionSpace(
+                        enriched_mesh_seq.meshes[n], element
                     )
 
-        return mesh_seq_e
+        return enriched_mesh_seq
 
     @staticmethod
     def _get_transfer_function(enrichment_method):
@@ -132,12 +132,12 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
         """
         enrichment_kwargs.setdefault("enrichment_method", "p")
         enrichment_kwargs.setdefault("num_enrichments", 1)
-        mesh_seq_e = self.get_enriched_mesh_seq(**enrichment_kwargs)
+        enriched_mesh_seq = self.get_enriched_mesh_seq(**enrichment_kwargs)
         transfer = self._get_transfer_function(enrichment_kwargs["enrichment_method"])
 
         # Solve the forward and adjoint problems on the MeshSeq and its enriched version
         self.solve_adjoint(**adj_kwargs)
-        mesh_seq_e.solve_adjoint(**adj_kwargs)
+        enriched_mesh_seq.solve_adjoint(**adj_kwargs)
 
         FWD, ADJ = "forward", "adjoint"
         FWD_OLD = "forward" if self.steady else "forward_old"
@@ -146,7 +146,9 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
         for i, mesh in enumerate(self):
             # Get Functions
             u, u_, u_star, u_star_next, u_star_e = {}, {}, {}, {}, {}
-            enriched_spaces = {f: mesh_seq_e.function_spaces[f][i] for f in self.fields}
+            enriched_spaces = {
+                f: enriched_mesh_seq.function_spaces[f][i] for f in self.fields
+            }
             mapping = {}
             for f, fs_e in enriched_spaces.items():
                 u[f] = Function(fs_e)
@@ -157,7 +159,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
                 u_star_e[f] = Function(fs_e)
 
             # Get forms for each equation in enriched space
-            forms = mesh_seq_e.form(i, mapping)
+            forms = enriched_mesh_seq.form(i, mapping)
             if not isinstance(forms, dict):
                 raise TypeError(
                     "The function defined by get_form should return a dictionary"
@@ -179,8 +181,8 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
                     u_star_e[f].assign(
                         0.5
                         * (
-                            mesh_seq_e.solutions[f][ADJ][i][j]
-                            + mesh_seq_e.solutions[f][ADJ_NEXT][i][j]
+                            enriched_mesh_seq.solutions[f][ADJ][i][j]
+                            + enriched_mesh_seq.solutions[f][ADJ_NEXT][i][j]
                         )
                     )
                     u_star_e[f] -= u_star[f]

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -47,6 +47,10 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
 
         # Apply h-refinement
         if enrichment_method == "h":
+            if any(mesh == self.meshes[0] for mesh in self.meshes[1:]):
+                raise ValueError(
+                    "h-enrichment is not supported for shallow-copied meshes."
+                )
             meshes = [MeshHierarchy(mesh, num_enrichments)[-1] for mesh in self.meshes]
         else:
             meshes = self.meshes

--- a/test_adjoint/test_mesh_seq.py
+++ b/test_adjoint/test_mesh_seq.py
@@ -131,7 +131,7 @@ class TestGetSolveBlocks(unittest.TestCase):
         self.assertEqual(str(cm.exception), msg)
 
 
-class TrivalGoalOrientedBaseClass(unittest.TestCase):
+class TrivialGoalOrientedBaseClass(unittest.TestCase):
     """
     Base class for tests with a trivial :class:`GoalOrientedMeshSeq`.
     """
@@ -140,6 +140,11 @@ class TrivalGoalOrientedBaseClass(unittest.TestCase):
         self.field = "field"
         self.time_interval = TimeInterval(1.0, [1.0], [self.field])
         self.meshes = [UnitSquareMesh(1, 1)]
+
+    @staticmethod
+    def constant_qoi(mesh_seq, solutions, index):
+        R = FunctionSpace(mesh_seq[index], "R", 0)
+        return lambda: Function(R).assign(1) * dx
 
     def go_mesh_seq(self, get_function_spaces, parameters=None):
         return GoalOrientedMeshSeq(
@@ -151,7 +156,7 @@ class TrivalGoalOrientedBaseClass(unittest.TestCase):
         )
 
 
-class TestGlobalEnrichment(TrivalGoalOrientedBaseClass):
+class TestGlobalEnrichment(TrivialGoalOrientedBaseClass):
     """
     Unit tests for global enrichment of a :class:`GoalOrientedMeshSeq`.
     """
@@ -317,15 +322,10 @@ class TestGlobalEnrichment(TrivalGoalOrientedBaseClass):
         self.assertAlmostEqual(norm(source), norm(target))
 
 
-class TestErrorIndication(TrivalGoalOrientedBaseClass):
+class TestErrorIndication(TrivialGoalOrientedBaseClass):
     """
     Unit tests for :meth:`indicate_errors`.
     """
-
-    @staticmethod
-    def constant_qoi(mesh_seq, solutions, index):
-        R = FunctionSpace(mesh_seq[index], "R", 0)
-        return lambda: Function(R).assign(1) * dx
 
     def test_form_error(self):
         mesh_seq = GoalOrientedMeshSeq(

--- a/test_adjoint/test_mesh_seq.py
+++ b/test_adjoint/test_mesh_seq.py
@@ -186,6 +186,21 @@ class TestGlobalEnrichment(TrivialGoalOrientedBaseClass):
         msg = "A positive number of enrichments is required."
         self.assertEqual(str(cm.exception), msg)
 
+    def test_h_enrichment_error(self):
+        end_time = 1.0
+        num_subintervals = 2
+        dt = end_time / num_subintervals
+        mesh_seq = GoalOrientedMeshSeq(
+            TimePartition(end_time, num_subintervals, dt, "field"),
+            [UnitTriangleMesh()] * num_subintervals,
+            get_qoi=self.constant_qoi,
+            qoi_type="end_time",
+        )
+        with self.assertRaises(ValueError) as cm:
+            mesh_seq.get_enriched_mesh_seq(enrichment_method="h")
+        msg = "h-enrichment is not supported for shallow-copied meshes."
+        self.assertEqual(str(cm.exception), msg)
+
     @parameterized.expand([[1], [2]])
     def test_h_enrichment_mesh(self, num_enrichments):
         """


### PR DESCRIPTION
Closes #110.

This PR should stop the user from h-enriching shallow-copied meshes, thereby fixing the bug raised.

As discussed in #112.