### PR TITLE
Introduce `SolutionData` and `IndicatorData` classes

### DIFF
--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -5,7 +5,7 @@ Drivers for solving adjoint problems on sequences of meshes.
 import firedrake
 from firedrake.petsc import PETSc
 from firedrake.adjoint import pyadjoint
-from .function_data import SteadyAdjointSolutionData, UnsteadyAdjointSolutionData
+from .function_data import AdjointSolutionData
 from .interpolation import project
 from .mesh_seq import MeshSeq
 from .options import GoalOrientedParameters
@@ -176,8 +176,7 @@ class AdjointMeshSeq(MeshSeq):
         return solve_blocks
 
     def _create_solutions(self):
-        cls = SteadyAdjointSolutionData if self.steady else UnsteadyAdjointSolutionData
-        self._solutions = cls(self.time_partition, self.function_spaces)
+        self._solutions = AdjointSolutionData(self.time_partition, self.function_spaces)
 
     @PETSc.Log.EventDecorator()
     def solve_adjoint(

--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -5,10 +5,10 @@ Drivers for solving adjoint problems on sequences of meshes.
 import firedrake
 from firedrake.petsc import PETSc
 from firedrake.adjoint import pyadjoint
+from .function_data import SteadyAdjointSolutionData, UnsteadyAdjointSolutionData
 from .interpolation import project
 from .mesh_seq import MeshSeq
 from .options import GoalOrientedParameters
-from .solutions import SteadyAdjointSolutionData, UnsteadyAdjointSolutionData
 from .time_partition import TimePartition
 from .utility import AttrDict, norm
 from .log import pyrint

--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -193,13 +193,14 @@ class AdjointMeshSeq(MeshSeq):
         computed, the contents of which give values at all exported timesteps, indexed
         first by the field label and then by type. The contents of these nested
         dictionaries are lists which are indexed first by subinterval and then by
-        export. For a given exported timestep, the solution types are:
+        export. For a given exported timestep, the field types are:
 
         * ``'forward'``: the forward solution after taking the timestep;
-        * ``'forward_old'``: the forward solution before taking the timestep
+        * ``'forward_old'``: the forward solution before taking the timestep (provided
+          the problem is not steady-state)
         * ``'adjoint'``: the adjoint solution after taking the timestep;
         * ``'adjoint_next'``: the adjoint solution before taking the timestep
-          (backwards).
+          backwards (provided the problem is not steady-state).
 
         :kwarg solver_kwargs: a dictionary providing parameters to the solver. Any
             keyword arguments for the QoI should be included as a subdict with label
@@ -347,7 +348,7 @@ class AdjointMeshSeq(MeshSeq):
 
                     # Lagged forward solution comes from dependencies
                     dep = self._dependency(field, i, block)
-                    if dep is not None:
+                    if not self.steady and dep is not None:
                         sols.forward_old[i][j].assign(dep.saved_output)
 
                     # Adjoint action also comes from dependencies

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -132,7 +132,7 @@ class IndicatorData(FunctionData):
     than a doubly-nested dictionary.
     """
 
-    labels = "error_indicator"
+    labels = ("error_indicator",)
 
     def __init__(self, time_partition, meshes):
         """

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -4,8 +4,8 @@ Drivers for goal-oriented error estimation on sequences of meshes.
 
 from .adjoint import AdjointMeshSeq
 from .error_estimation import get_dwr_indicator
+from .function_data import IndicatorData
 from .log import pyrint
-from .solutions import IndicatorData
 from .utility import AttrDict
 from firedrake import Function, FunctionSpace, MeshHierarchy, TransferManager, project
 from firedrake.petsc import PETSc

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -5,6 +5,7 @@ Drivers for goal-oriented error estimation on sequences of meshes.
 from .adjoint import AdjointMeshSeq
 from .error_estimation import get_dwr_indicator
 from .log import pyrint
+from .solutions import IndicatorData
 from .utility import AttrDict
 from firedrake import Function, FunctionSpace, MeshHierarchy, TransferManager, project
 from firedrake.petsc import PETSc
@@ -88,21 +89,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             return lambda source, target: target.interpolate(source)
 
     def _create_indicators(self):
-        P0_spaces = [FunctionSpace(mesh, "DG", 0) for mesh in self]
-        self._indicators = AttrDict(
-            {
-                field: [
-                    [
-                        Function(fs, name=f"{field}_error_indicator")
-                        for _ in range(
-                            self.time_partition.num_exports_per_subinterval[i] - 1
-                        )
-                    ]
-                    for i, fs in enumerate(P0_spaces)
-                ]
-                for field in self.fields
-            }
-        )
+        self._indicators = IndicatorData(self.time_partition, self.meshes)
 
     @property
     def indicators(self):
@@ -203,7 +190,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
 
         :kwarg absolute_value: toggle whether to take the modulus on each element
         """
-        assert isinstance(self.indicators, dict)
+        assert isinstance(self.indicators, IndicatorData)
         if not isinstance(absolute_value, bool):
             raise TypeError(
                 f"Expected 'absolute_value' to be a bool, not '{type(absolute_value)}'."

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -11,6 +11,7 @@ from .interpolation import project
 from .log import pyrint, debug, warning, info, logger, DEBUG
 from .options import AdaptParameters
 from animate.quality import QualityMeasure
+from .solutions import ForwardSolutionData
 from .time_partition import TimePartition
 from .utility import AttrDict, Mesh
 from collections import OrderedDict
@@ -489,25 +490,7 @@ class MeshSeq:
             )
 
     def _create_solutions(self):
-        P = self.time_partition
-        labels = ("forward", "forward_old")
-        self._solutions = AttrDict(
-            {
-                field: AttrDict(
-                    {
-                        label: [
-                            [
-                                firedrake.Function(fs, name=f"{field}_{label}")
-                                for j in range(P.num_exports_per_subinterval[i] - 1)
-                            ]
-                            for i, fs in enumerate(self.function_spaces[field])
-                        ]
-                        for label in labels
-                    }
-                )
-                for field in self.fields
-            }
-        )
+        self._solutions = ForwardSolutionData(self.time_partition, self.function_spaces)
 
     @property
     def solutions(self):

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -510,10 +510,11 @@ class MeshSeq:
         at all exported timesteps, indexed first by the field label and then by type.
         The contents of these nested dictionaries are nested lists which are indexed
         first by subinterval and then by export. For a given exported timestep, the
-        solution types are:
+        field types are:
 
         * ``'forward'``: the forward solution after taking the timestep;
-        * ``'forward_old'``: the forward solution before taking the timestep.
+        * ``'forward_old'``: the forward solution before taking the timestep (provided
+          the problem is not steady-state).
 
         :kwarg solver_kwargs: a dictionary providing parameters to the solver. Any
             keyword arguments for the QoI should be included as a subdict with label
@@ -577,7 +578,7 @@ class MeshSeq:
 
                     # Lagged solution comes from dependencies
                     dep = self._dependency(field, i, block)
-                    if dep is not None:
+                    if not self.steady and dep is not None:
                         sols.forward_old[i][j].assign(dep.saved_output)
 
             # Transfer the checkpoint between subintervals

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -7,11 +7,11 @@ from firedrake.adjoint import pyadjoint
 from firedrake.adjoint_utils.solving import get_solve_blocks
 from firedrake.petsc import PETSc
 from firedrake.pyplot import triplot
+from .function_data import ForwardSolutionData
 from .interpolation import project
 from .log import pyrint, debug, warning, info, logger, DEBUG
 from .options import AdaptParameters
 from animate.quality import QualityMeasure
-from .solutions import ForwardSolutionData
 from .time_partition import TimePartition
 from .utility import AttrDict, Mesh
 from collections import OrderedDict

--- a/goalie/solutions.py
+++ b/goalie/solutions.py
@@ -1,0 +1,57 @@
+r"""
+Nested dictionaries of solution data :class:`~.Function`\s.
+"""
+import firedrake.function as ffunc
+from .utility import AttrDict
+import abc
+
+__all__ = ["ForwardSolutionData"]
+
+
+class SolutionData(abc.ABC):
+    """
+    Abstract base class that defines the API for solution data classes.
+    """
+
+    labels = None
+
+    def __init__(self, time_partition, function_spaces):
+        r"""
+        :arg time_partition: the :class:`~.TimePartition` used to discretise the problem
+            in time
+        :arg function_spaces: the dictionary of :class:`~.FunctionSpace`\s used to
+            discretise the problem in space
+        """
+        self.time_partition = time_partition
+        self.function_spaces = function_spaces
+        self._solutions = None
+        self._create_solutions()
+
+    def _create_solutions(self):
+        assert self.labels is not None
+        P = self.time_partition
+        self._solutions = AttrDict(
+            {
+                field: AttrDict(
+                    {
+                        label: [
+                            [
+                                ffunc.Function(fs, name=f"{field}_{label}")
+                                for j in range(P.num_exports_per_subinterval[i] - 1)
+                            ]
+                            for i, fs in enumerate(self.function_spaces[field])
+                        ]
+                        for label in self.labels
+                    }
+                )
+                for field in P.fields
+            }
+        )
+
+
+class ForwardSolutionData(SolutionData):
+    """
+    Class representing solution data for forward problems.
+    """
+
+    labels = ("forward", "forward_old")

--- a/goalie/solutions.py
+++ b/goalie/solutions.py
@@ -5,7 +5,12 @@ import firedrake.function as ffunc
 from .utility import AttrDict
 import abc
 
-__all__ = ["ForwardSolutionData"]
+__all__ = [
+    "ForwardSolutionData",
+    "SteadyAdjointSolutionData",
+    "UnsteadyAdjointSolutionData",
+    "AdjointSolutionData",
+]
 
 
 class SolutionData(abc.ABC):
@@ -64,3 +69,25 @@ class ForwardSolutionData(SolutionData):
     """
 
     labels = ("forward", "forward_old")
+
+
+class SteadyAdjointSolutionData(SolutionData):
+    """
+    Class representing solution data for steady-state adjoint problems.
+    """
+
+    labels = ("forward", "forward_old", "adjoint")
+
+
+class UnsteadyAdjointSolutionData(SolutionData):
+    """
+    Class representing solution data for time-dependent adjoint problems.
+    """
+
+    labels = ("forward", "forward_old", "adjoint", "adjoint_next")
+
+
+class AdjointSolutionData(UnsteadyAdjointSolutionData):
+    """
+    Class representing solution data for general adjoint problems.
+    """

--- a/goalie/solutions.py
+++ b/goalie/solutions.py
@@ -48,6 +48,15 @@ class SolutionData(abc.ABC):
             }
         )
 
+    @property
+    def solutions(self):
+        if self._solutions is None:
+            self._create_solutions()
+        return self._solutions
+
+    def __getitem__(self, key):
+        return self.solutions[key]
+
 
 class ForwardSolutionData(SolutionData):
     """

--- a/goalie/solutions.py
+++ b/goalie/solutions.py
@@ -151,3 +151,6 @@ class IndicatorData:
 
     def __getitem__(self, key):
         return self.indicators[key]
+
+    def items(self):
+        return self.indicators.items()

--- a/goalie/solutions.py
+++ b/goalie/solutions.py
@@ -6,6 +6,8 @@ from .utility import AttrDict
 import abc
 
 __all__ = [
+    "SteadyForwardSolutionData",
+    "UnsteadyForwardSolutionData",
     "ForwardSolutionData",
     "SteadyAdjointSolutionData",
     "UnsteadyAdjointSolutionData",
@@ -63,12 +65,26 @@ class SolutionData(abc.ABC):
         return self.solutions[key]
 
 
-class ForwardSolutionData(SolutionData):
+class SteadyForwardSolutionData(SolutionData):
     """
-    Class representing solution data for forward problems.
+    Class representing solution data for steady-state forward problems.
+    """
+
+    labels = ("forward",)
+
+
+class UnsteadyForwardSolutionData(SolutionData):
+    """
+    Class representing solution data for time-dependent forward problems.
     """
 
     labels = ("forward", "forward_old")
+
+
+class ForwardSolutionData(UnsteadyForwardSolutionData):
+    """
+    Class representing solution data for general forward problems.
+    """
 
 
 class SteadyAdjointSolutionData(SolutionData):

--- a/test/test_error_estimation.py
+++ b/test/test_error_estimation.py
@@ -3,8 +3,8 @@ from goalie.error_estimation import (
     form2indicator,
     get_dwr_indicator,
 )
+from goalie.function_data import IndicatorData
 from goalie.go_mesh_seq import GoalOrientedMeshSeq
-from goalie.solutions import IndicatorData
 from goalie.time_partition import TimeInstant, TimePartition
 from parameterized import parameterized
 import unittest


### PR DESCRIPTION
Partially addresses #26.

[Putting all of you as reviewers mainly to make you aware I finally got round to this.]

This PR introduces `SolutionData` and `IndicatorData` classes which should fit seamlessly with the current API. They have a common base class, so we avoid duplication in how the nested dictionaries and arrays are set up.

Once this is merged, I'll open two follow-up PRs:
* One to provide different access methods, i.e., by label, by subinterval, as well as the existing access by field.
* Move the plotting functionality to live on these classes.