### PR TITLE
Alternative data access methods for `FunctionData` and subclasses

### DIFF
--- a/goalie/__init__.py
+++ b/goalie/__init__.py
@@ -8,6 +8,7 @@ from goalie.mesh_seq import *  # noqa
 from goalie.options import *  # noqa
 from goalie.point_seq import *  # noqa
 from goalie.interpolation import *  # noqa
+from goalie.function_data import *  # noqa
 from goalie.error_estimation import *  # noqa
 
 import numpy as np  # noqa

--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -274,9 +274,9 @@ class AdjointMeshSeq(MeshSeq):
 
         if get_adj_values:
             for field in self.fields:
-                self.solutions[field]["adj_value"] = []
+                self.solutions.extract(layout="field")[field]["adj_value"] = []
                 for i, fs in enumerate(self.function_spaces[field]):
-                    self.solutions[field]["adj_value"].append(
+                    self.solutions.extract(layout="field")[field]["adj_value"].append(
                         [
                             firedrake.Cofunction(fs.dual(), name=f"{field}_adj_value")
                             for j in range(P.num_exports_per_subinterval[i] - 1)
@@ -383,7 +383,7 @@ class AdjointMeshSeq(MeshSeq):
 
                 # Update forward and adjoint solution data based on block dependencies
                 # and outputs
-                sols = self.solutions[field]
+                sols = self.solutions.extract(layout="field")[field]
                 for j, block in enumerate(reversed(solve_blocks[::-stride])):
                     # Current forward solution is determined from outputs
                     out = self._output(field, i, block)

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -94,26 +94,6 @@ class SolutionData(FunctionData, abc.ABC):
     Abstract base class that defines the API for solution data classes.
     """
 
-    @property
-    def solutions_by_field(self):
-        """
-        Extract solution data array in the default layout: as a doubly-nested dictionary
-        whose first key is the field name and second key is the field label. Entries
-        of the doubly-nested dictionary are doubly-nested lists, indexed first by
-        subinterval and then by export.
-        """
-        return self.data_by_field
-
-    @property
-    def solutions_by_label(self):
-        """
-        Extract solution data array in an alternative layout: as a doubly-nested dictionary
-        whose first key is the field label and second key is the field name. Entries
-        of the doubly-nested dictionary are doubly-nested lists, which retain the default
-        layout: indexed first by subinterval and then by export.
-        """
-        return self.data_by_label
-
 
 class ForwardSolutionData(SolutionData):
     """
@@ -161,30 +141,17 @@ class IndicatorData(FunctionData):
         )
 
     @property
-    def indicators_by_field(self):
+    def data_by_field(self):
         """
         Extract indicator data array in the default layout: as a dictionary keyed with
         the field name. Entries of the dictionary are doubly-nested lists, indexed first
         by subinterval and then by export.
         """
+        if self._data is None:
+            self._create_data()
         return AttrDict(
             {
-                field: self.data_by_field[field]["error_indicator"]
+                field: self._data[field]["error_indicator"]
                 for field in self.time_partition.fields
             }
         )
-
-    def __getitem__(self, key):
-        return self.indicators_by_field[key]
-
-    def items(self):
-        return self.indicators_by_field.items()
-
-    @property
-    def indicators_by_label(self):
-        """
-        Extract indicator data array in the default layout: as a dictionary keyed with
-        the field name. Entries of the dictionary are doubly-nested lists, indexed first
-        by subinterval and then by export.
-        """
-        return self.indicators_by_field

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -111,7 +111,7 @@ class FunctionData(abc.ABC):
                     for field in tp.fields
                 }
             )
-            for subinterval in tp.num_subintervals
+            for subinterval in range(tp.num_subintervals)
         ]
 
 
@@ -199,6 +199,8 @@ class IndicatorData(FunctionData):
         """
         tp = self.time_partition
         return [
-            AttrDict({self.data_by_field[field][subinterval] for field in tp.fields})
-            for subinterval in tp.num_subintervals
+            AttrDict(
+                {field: self.data_by_field[field][subinterval] for field in tp.fields}
+            )
+            for subinterval in range(tp.num_subintervals)
         ]

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -89,13 +89,7 @@ class FunctionData(abc.ABC):
         )
 
 
-class SolutionData(FunctionData, abc.ABC):
-    """
-    Abstract base class that defines the API for solution data classes.
-    """
-
-
-class ForwardSolutionData(SolutionData):
+class ForwardSolutionData(FunctionData):
     """
     Class representing solution data for general forward problems.
     """
@@ -105,7 +99,7 @@ class ForwardSolutionData(SolutionData):
         super().__init__(*args, **kwargs)
 
 
-class AdjointSolutionData(SolutionData):
+class AdjointSolutionData(FunctionData):
     """
     Class representing solution data for general adjoint problems.
     """

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -129,9 +129,12 @@ class IndicatorData(FunctionData):
         self.labels = {
             field_type: ("error_indicator",) for field_type in ("steady", "unsteady")
         }
-        P0_spaces = [ffs.FunctionSpace(mesh, "DG", 0) for mesh in meshes]
         super().__init__(
-            time_partition, {key: P0_spaces for key in time_partition.fields}
+            time_partition,
+            {
+                key: [ffs.FunctionSpace(mesh, "DG", 0) for mesh in meshes]
+                for key in time_partition.fields
+            },
         )
 
     @property

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -149,3 +149,11 @@ class IndicatorData(FunctionData):
                 for field in self.time_partition.fields
             }
         )
+
+    @property
+    def data_by_label(self):
+        """
+        For indicator data there is only one field label (``"error_indicator"``), so
+        this method just delegates to :meth:`~.data_by_field`.
+        """
+        return self.data_by_field

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -53,16 +53,22 @@ class FunctionData(abc.ABC):
         )
 
     @property
-    def data(self):
+    def data_by_field(self):
+        """
+        Extract field data array in the default layout: as a doubly-nested dictionary
+        whose first key is the field name and second key is the field label. Entries
+        of the doubly-nested dictionary are doubly-nested lists, indexed first by
+        subinterval and then by export.
+        """
         if self._data is None:
             self._create_data()
         return self._data
 
     def __getitem__(self, key):
-        return self.data[key]
+        return self.data_by_field[key]
 
     def items(self):
-        return self.data.items()
+        return self.data_by_field.items()
 
 
 class SolutionData(FunctionData, abc.ABC):
@@ -72,7 +78,7 @@ class SolutionData(FunctionData, abc.ABC):
 
     @property
     def solutions(self):
-        return self.data
+        return self.data_by_field
 
 
 class ForwardSolutionData(SolutionData):
@@ -126,11 +132,11 @@ class IndicatorData(FunctionData):
         P = self.time_partition
         self._data = AttrDict(
             {
-                field: self.data[field][self.labels[field_type][0]]
+                field: self.data_by_field[field][self.labels[field_type][0]]
                 for field, field_type in zip(P.fields, P.field_types)
             }
         )
 
     @property
     def indicators(self):
-        return self.data
+        return self.data_by_field

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -77,7 +77,13 @@ class SolutionData(FunctionData, abc.ABC):
     """
 
     @property
-    def solutions(self):
+    def solutions_by_field(self):
+        """
+        Extract solution data array in the default layout: as a doubly-nested dictionary
+        whose first key is the field name and second key is the field label. Entries
+        of the doubly-nested dictionary are doubly-nested lists, indexed first by
+        subinterval and then by export.
+        """
         return self.data_by_field
 
 
@@ -126,17 +132,22 @@ class IndicatorData(FunctionData):
             time_partition, {key: P0_spaces for key in time_partition.fields}
         )
 
-    def _create_data(self):
-        assert all(len(labels) == 1 for labels in self.labels.values())
-        super()._create_data()
-        P = self.time_partition
-        self._data = AttrDict(
+    @property
+    def indicators_by_field(self):
+        """
+        Extract indicator data array in the default layout: as a dictionary keyed with
+        the field name. Entries of the dictionary are doubly-nested lists, indexed first
+        by subinterval and then by export.
+        """
+        return AttrDict(
             {
-                field: self.data_by_field[field][self.labels[field_type][0]]
-                for field, field_type in zip(P.fields, P.field_types)
+                field: self.data_by_field[field]["error_indicator"]
+                for field in self.time_partition.fields
             }
         )
 
-    @property
-    def indicators(self):
-        return self.data_by_field
+    def __getitem__(self, key):
+        return self.indicators_by_field[key]
+
+    def items(self):
+        return self.indicators_by_field.items()

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -88,6 +88,32 @@ class FunctionData(abc.ABC):
             }
         )
 
+    @property
+    def data_by_subinterval(self):
+        """
+        Extract field data array in an alternative format: as a list indexed by
+        subinterval. Entries of the list are doubly-nested dictionaries, which retain
+        the default layout: with the first key being field label and the second key being
+        the field name. Entries of the doubly-nested dictionaries are lists of field
+        data, indexed by export.
+        """
+        tp = self.time_partition
+        return [
+            AttrDict(
+                {
+                    field: AttrDict(
+                        {
+                            self.labels[field_type]: self.data_by_field[field][
+                                self.labels[field_type]
+                            ][subinterval]
+                        }
+                    )
+                    for field, field_type in zip(tp.fields, tp.field_types)
+                }
+            )
+            for subinterval in tp.num_subintervals
+        ]
+
 
 class ForwardSolutionData(FunctionData):
     """
@@ -160,3 +186,16 @@ class IndicatorData(FunctionData):
         this method just delegates to :meth:`~.data_by_field`.
         """
         return self.data_by_field
+
+    @property
+    def data_by_subinterval(self):
+        """
+        Extract indicator data array in an alternative format: as a list indexed by
+        subinterval. Entries of the list are dictionaries, keyed by field label.
+        Entries of the dictionaries are lists of field data, indexed by export.
+        """
+        tp = self.time_partition
+        return [
+            AttrDict({self.data_by_field[field][subinterval] for field in tp.fields})
+            for subinterval in tp.num_subintervals
+        ]

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -33,7 +33,7 @@ class FunctionData(abc.ABC):
 
     def _create_data(self):
         assert self.labels
-        P = self.time_partition
+        tp = self.time_partition
         self._data = AttrDict(
             {
                 field: AttrDict(
@@ -41,14 +41,14 @@ class FunctionData(abc.ABC):
                         label: [
                             [
                                 ffunc.Function(fs, name=f"{field}_{label}")
-                                for j in range(P.num_exports_per_subinterval[i] - 1)
+                                for j in range(tp.num_exports_per_subinterval[i] - 1)
                             ]
                             for i, fs in enumerate(self.function_spaces[field])
                         ]
                         for label in self.labels[field_type]
                     }
                 )
-                for field, field_type in zip(P.fields, P.field_types)
+                for field, field_type in zip(tp.fields, tp.field_types)
             }
         )
 

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -114,6 +114,35 @@ class FunctionData(abc.ABC):
             for subinterval in range(tp.num_subintervals)
         ]
 
+    def extract(self, layout="field"):
+        """
+        Extract field data array in a specified layout.
+
+        The default layout is a doubly-nested dictionary whose first key is the field
+        name and second key is the field label. Entries of the doubly-nested dictionary
+        are doubly-nested lists, indexed first by subinterval and then by export. That
+        is: ``data[field][label][subinterval][export]``.
+
+        Choosing a different layout simply promotes the specified variable to first
+        access:
+        * ``layout == "label"`` implies ``data[label][field][subinterval][export]``
+        * ``layout == "subinterval"`` implies ``data[subinterval][label][field][export]``
+
+        The export index is not promoted because the number of exports may differ across
+        subintervals.
+
+        :kwarg layout: the layout to promote, as described above
+        :type layout: :class:`str`
+        """
+        if layout == "field":
+            return self._data_by_field
+        elif layout == "label":
+            return self._data_by_label
+        elif layout == "subinterval":
+            return self._data_by_subinterval
+        else:
+            raise ValueError(f"Layout type '{layout}' not recognised.")
+
 
 class ForwardSolutionData(FunctionData):
     """

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -79,12 +79,13 @@ class FunctionData(abc.ABC):
         layout: indexed first by subinterval and then by export.
         """
         tp = self.time_partition
+        labels = self.labels["steady"] + self.labels["unsteady"]
         return AttrDict(
             {
-                self.labels[field_type]: AttrDict(
-                    {field: self.data_by_field[field][self.labels[field_type]]}
+                label: AttrDict(
+                    {field: self.data_by_field[field][label] for field in tp.fields}
                 )
-                for field, field_type in zip(tp.fields, tp.field_types)
+                for label in labels
             }
         )
 
@@ -98,17 +99,17 @@ class FunctionData(abc.ABC):
         data, indexed by export.
         """
         tp = self.time_partition
+        labels = self.labels["steady"] + self.labels["unsteady"]
         return [
             AttrDict(
                 {
                     field: AttrDict(
                         {
-                            self.labels[field_type]: self.data_by_field[field][
-                                self.labels[field_type]
-                            ][subinterval]
+                            label: self.data_by_field[field][label][subinterval]
+                            for label in labels
                         }
                     )
-                    for field, field_type in zip(tp.fields, tp.field_types)
+                    for field in tp.fields
                 }
             )
             for subinterval in tp.num_subintervals

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -30,6 +30,7 @@ class FunctionData(abc.ABC):
         self.time_partition = time_partition
         self.function_spaces = function_spaces
         self._data = None
+        self.labels = self._label_dict["steady"] + self._label_dict["unsteady"]
 
     def _create_data(self):
         assert self._label_dict
@@ -79,13 +80,12 @@ class FunctionData(abc.ABC):
         layout: indexed first by subinterval and then by export.
         """
         tp = self.time_partition
-        labels = self._label_dict["steady"] + self._label_dict["unsteady"]
         return AttrDict(
             {
                 label: AttrDict(
                     {field: self.data_by_field[field][label] for field in tp.fields}
                 )
-                for label in labels
+                for label in self.labels
             }
         )
 
@@ -99,14 +99,13 @@ class FunctionData(abc.ABC):
         data, indexed by export.
         """
         tp = self.time_partition
-        labels = self._label_dict["steady"] + self._label_dict["unsteady"]
         return [
             AttrDict(
                 {
                     field: AttrDict(
                         {
                             label: self.data_by_field[field][label][subinterval]
-                            for label in labels
+                            for label in self.labels
                         }
                     )
                     for field in tp.fields

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -126,7 +126,7 @@ class FunctionData(abc.ABC):
         Choosing a different layout simply promotes the specified variable to first
         access:
         * ``layout == "label"`` implies ``data[label][field][subinterval][export]``
-        * ``layout == "subinterval"`` implies ``data[subinterval][label][field][export]``
+        * ``layout == "subinterval"`` implies ``data[subinterval][field][label][export]``
 
         The export index is not promoted because the number of exports may differ across
         subintervals.

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -54,7 +54,7 @@ class FunctionData(abc.ABC):
         )
 
     @property
-    def data_by_field(self):
+    def _data_by_field(self):
         """
         Extract field data array in the default layout: as a doubly-nested dictionary
         whose first key is the field name and second key is the field label. Entries
@@ -66,13 +66,13 @@ class FunctionData(abc.ABC):
         return self._data
 
     def __getitem__(self, key):
-        return self.data_by_field[key]
+        return self._data_by_field[key]
 
     def items(self):
-        return self.data_by_field.items()
+        return self._data_by_field.items()
 
     @property
-    def data_by_label(self):
+    def _data_by_label(self):
         """
         Extract field data array in an alternative layout: as a doubly-nested dictionary
         whose first key is the field label and second key is the field name. Entries
@@ -83,14 +83,14 @@ class FunctionData(abc.ABC):
         return AttrDict(
             {
                 label: AttrDict(
-                    {field: self.data_by_field[field][label] for field in tp.fields}
+                    {field: self._data_by_field[field][label] for field in tp.fields}
                 )
                 for label in self.labels
             }
         )
 
     @property
-    def data_by_subinterval(self):
+    def _data_by_subinterval(self):
         """
         Extract field data array in an alternative format: as a list indexed by
         subinterval. Entries of the list are doubly-nested dictionaries, which retain
@@ -104,7 +104,7 @@ class FunctionData(abc.ABC):
                 {
                     field: AttrDict(
                         {
-                            label: self.data_by_field[field][label][subinterval]
+                            label: self._data_by_field[field][label][subinterval]
                             for label in self.labels
                         }
                     )
@@ -167,7 +167,7 @@ class IndicatorData(FunctionData):
         )
 
     @property
-    def data_by_field(self):
+    def _data_by_field(self):
         """
         Extract indicator data array in the default layout: as a dictionary keyed with
         the field name. Entries of the dictionary are doubly-nested lists, indexed first
@@ -183,15 +183,15 @@ class IndicatorData(FunctionData):
         )
 
     @property
-    def data_by_label(self):
+    def _data_by_label(self):
         """
         For indicator data there is only one field label (``"error_indicator"``), so
-        this method just delegates to :meth:`~.data_by_field`.
+        this method just delegates to :meth:`~._data_by_field`.
         """
-        return self.data_by_field
+        return self._data_by_field
 
     @property
-    def data_by_subinterval(self):
+    def _data_by_subinterval(self):
         """
         Extract indicator data array in an alternative format: as a list indexed by
         subinterval. Entries of the list are dictionaries, keyed by field label.
@@ -200,7 +200,7 @@ class IndicatorData(FunctionData):
         tp = self.time_partition
         return [
             AttrDict(
-                {field: self.data_by_field[field][subinterval] for field in tp.fields}
+                {field: self._data_by_field[field][subinterval] for field in tp.fields}
             )
             for subinterval in range(tp.num_subintervals)
         ]

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -94,8 +94,8 @@ class FunctionData(abc.ABC):
         """
         Extract field data array in an alternative format: as a list indexed by
         subinterval. Entries of the list are doubly-nested dictionaries, which retain
-        the default layout: with the first key being field label and the second key being
-        the field name. Entries of the doubly-nested dictionaries are lists of field
+        the default layout: with the first key being field name and the second key being
+        the field label. Entries of the doubly-nested dictionaries are lists of field
         data, indexed by export.
         """
         tp = self.time_partition

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -70,6 +70,24 @@ class FunctionData(abc.ABC):
     def items(self):
         return self.data_by_field.items()
 
+    @property
+    def data_by_label(self):
+        """
+        Extract field data array in an alternative layout: as a doubly-nested dictionary
+        whose first key is the field label and second key is the field name. Entries
+        of the doubly-nested dictionary are doubly-nested lists, which retain the default
+        layout: indexed first by subinterval and then by export.
+        """
+        tp = self.time_partition
+        return AttrDict(
+            {
+                self.labels[field_type]: AttrDict(
+                    {field: self.data_by_field[field][self.labels[field_type]]}
+                )
+                for field, field_type in zip(tp.fields, tp.field_types)
+            }
+        )
+
 
 class SolutionData(FunctionData, abc.ABC):
     """
@@ -85,6 +103,16 @@ class SolutionData(FunctionData, abc.ABC):
         subinterval and then by export.
         """
         return self.data_by_field
+
+    @property
+    def solutions_by_label(self):
+        """
+        Extract solution data array in an alternative layout: as a doubly-nested dictionary
+        whose first key is the field label and second key is the field name. Entries
+        of the doubly-nested dictionary are doubly-nested lists, which retain the default
+        layout: indexed first by subinterval and then by export.
+        """
+        return self.data_by_label
 
 
 class ForwardSolutionData(SolutionData):
@@ -151,3 +179,12 @@ class IndicatorData(FunctionData):
 
     def items(self):
         return self.indicators_by_field.items()
+
+    @property
+    def indicators_by_label(self):
+        """
+        Extract indicator data array in the default layout: as a dictionary keyed with
+        the field name. Entries of the dictionary are doubly-nested lists, indexed first
+        by subinterval and then by export.
+        """
+        return self.indicators_by_field

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -187,7 +187,8 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             # Loop over each strongly coupled field
             for f in self.fields:
                 # Loop over each timestep
-                for j in range(len(self.solutions[f]["forward"][i])):
+                solutions = self.solutions.extract(layout="field")
+                for j in range(len(solutions[f]["forward"][i])):
                     # Update fields
                     transfer(self.solutions[f][FWD][i][j], u[f])
                     transfer(self.solutions[f][FWD_OLD][i][j], u_[f])

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -188,6 +188,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             for f in self.fields:
                 # Loop over each timestep
                 solutions = self.solutions.extract(layout="field")
+                indicators = self.indicators.extract(layout="field")
                 for j in range(len(solutions[f]["forward"][i])):
                     # Update fields
                     transfer(self.solutions[f][FWD][i][j], u[f])
@@ -212,7 +213,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
                     # Project back to the base space
                     indi = project(indi_e, P0_spaces[i])
                     indi.interpolate(abs(indi))
-                    self.indicators[f][i][j].interpolate(ufl.max_value(indi, 1.0e-16))
+                    indicators[f][i][j].interpolate(ufl.max_value(indi, 1.0e-16))
 
         return self.solutions, self.indicators
 

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -729,7 +729,7 @@ class MeshSeq:
                     )
 
                 # Update solution data based on block dependencies and outputs
-                sols = self.solutions[field]
+                sols = self.solutions.extract(layout="field")[field]
                 for j, block in enumerate(reversed(solve_blocks[::-stride])):
                     # Current solution is determined from outputs
                     out = self._output(field, i, block)

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -449,14 +449,14 @@ class MeshSeq:
         # Otherwise, solve each subsequent subinterval, in each case making use of the
         # previous checkpoint
         for i in range(N if run_final_subinterval else N - 1):
-            sols = self.solver(i, checkpoints[i], **solver_kwargs)
-            if not isinstance(sols, dict):
+            solutions = self.solver(i, checkpoints[i], **solver_kwargs)
+            if not isinstance(solutions, dict):
                 raise TypeError(
-                    f"Solver should return a dictionary, not '{type(sols)}'."
+                    f"Solver should return a dictionary, not '{type(solutions)}'."
                 )
 
             # Check that the output of the solver is as expected
-            fields = set(sols.keys())
+            fields = set(solutions.keys())
             if not set(self.fields).issubset(fields):
                 diff = set(self.fields).difference(fields)
                 raise ValueError(f"Fields are missing from the solver: {diff}.")
@@ -469,7 +469,7 @@ class MeshSeq:
                 checkpoints.append(
                     AttrDict(
                         {
-                            field: project(sols[field], fs[i + 1])
+                            field: project(solutions[field], fs[i + 1])
                             for field, fs in self._fs.items()
                         }
                     )
@@ -729,17 +729,17 @@ class MeshSeq:
                     )
 
                 # Update solution data based on block dependencies and outputs
-                sols = self.solutions.extract(layout="field")[field]
+                solutions = self.solutions.extract(layout="field")[field]
                 for j, block in enumerate(reversed(solve_blocks[::-stride])):
                     # Current solution is determined from outputs
                     out = self._output(field, i, block)
                     if out is not None:
-                        sols.forward[i][j].assign(out.saved_output)
+                        solutions.forward[i][j].assign(out.saved_output)
 
                     # Lagged solution comes from dependencies
                     dep = self._dependency(field, i, block)
                     if not self.steady and dep is not None:
-                        sols.forward_old[i][j].assign(dep.saved_output)
+                        solutions.forward_old[i][j].assign(dep.saved_output)
 
             # Transfer the checkpoint between subintervals
             if i < num_subintervals - 1:

--- a/test/test_function_data.py
+++ b/test/test_function_data.py
@@ -41,7 +41,7 @@ class BaseTestCases:
             pass
 
         def test_data_by_field(self):
-            data = self.solution_data.data_by_field
+            data = self.solution_data._data_by_field
             self.assertTrue(isinstance(data, AttrDict))
             self.assertTrue(self.field in data)
             for label in self.labels:
@@ -56,7 +56,7 @@ class BaseTestCases:
                         self.assertTrue(isinstance(f, Function))
 
         def test_data_by_label(self):
-            data = self.solution_data.data_by_label
+            data = self.solution_data._data_by_label
             self.assertTrue(isinstance(data, AttrDict))
             for label in self.labels:
                 self.assertTrue(label in data)
@@ -71,7 +71,7 @@ class BaseTestCases:
                         self.assertTrue(isinstance(f, Function))
 
         def test_data_by_subinterval(self):
-            data = self.solution_data.data_by_subinterval
+            data = self.solution_data._data_by_subinterval
             self.assertTrue(isinstance(data, list))
             self.assertEqual(len(data), self.num_subintervals)
             for i, sub_data in enumerate(data):
@@ -134,9 +134,9 @@ class TestIndicatorData(BaseTestCases.TestFunctionData):
 
     def _test_data_by_field_or_label(self, field_or_data):
         if field_or_data == "field":
-            data = self.solution_data.data_by_field
+            data = self.solution_data._data_by_field
         else:
-            data = self.solution_data.data_by_label
+            data = self.solution_data._data_by_label
         self.assertTrue(isinstance(data, AttrDict))
         self.assertTrue(self.field in data)
         self.assertEqual(len(data[self.field]), self.num_subintervals)
@@ -153,7 +153,7 @@ class TestIndicatorData(BaseTestCases.TestFunctionData):
         self._test_data_by_field_or_label("label")
 
     def test_data_by_subinterval(self):
-        data = self.solution_data.data_by_subinterval
+        data = self.solution_data._data_by_subinterval
         self.assertTrue(isinstance(data, list))
         self.assertEqual(len(data), self.num_subintervals)
         for i, sub_data in enumerate(data):

--- a/test/test_function_data.py
+++ b/test/test_function_data.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for :class:`~.FunctionData` and its subclasses.
+"""
+from firedrake import *
+from goalie import *
+import unittest
+
+
+class TestForwardSolutionData(unittest.TestCase):
+    """
+    Unit tests for :class:`~.ForwardSolutionData`.
+    """
+
+    def setUp(self):
+        end_time = 1.0
+        self.num_subintervals = 2
+        timesteps = [0.5, 0.25]
+        self.field = "field"
+        self.labels = ("forward", "forward_old")
+        self.num_exports = [1, 2]
+        mesh = UnitTriangleMesh()
+        self.time_partition = TimePartition(
+            end_time, self.num_subintervals, timesteps, self.field
+        )
+        self.function_spaces = {
+            self.field: [
+                FunctionSpace(mesh, "DG", 0) for _ in range(self.num_subintervals)
+            ]
+        }
+        self._create_solution_data()
+
+    def _create_solution_data(self):
+        self.solution_data = ForwardSolutionData(
+            self.time_partition, self.function_spaces
+        )
+
+    def test_data_by_field(self):
+        data = self.solution_data.data_by_field
+        self.assertTrue(isinstance(data, AttrDict))
+        self.assertTrue(self.field in data)
+        for label in self.labels:
+            self.assertTrue(isinstance(data[self.field], AttrDict))
+            self.assertTrue(label in data[self.field])
+            self.assertTrue(isinstance(data[self.field][label], list))
+            self.assertEqual(len(data[self.field][label]), self.num_subintervals)
+            for i, num_exports in enumerate(self.num_exports):
+                self.assertTrue(isinstance(data[self.field][label][i], list))
+                self.assertEqual(len(data[self.field][label][i]), num_exports)
+                for f in data[self.field][label][i]:
+                    self.assertTrue(isinstance(f, Function))
+
+    def test_data_by_label(self):
+        data = self.solution_data.data_by_label
+        self.assertTrue(isinstance(data, AttrDict))
+        for label in self.labels:
+            self.assertTrue(label in data)
+            self.assertTrue(isinstance(data[label], AttrDict))
+            self.assertTrue(self.field in data[label])
+            self.assertTrue(isinstance(data[label][self.field], list))
+            self.assertEqual(len(data[label][self.field]), self.num_subintervals)
+            for i, num_exports in enumerate(self.num_exports):
+                self.assertTrue(isinstance(data[label][self.field][i], list))
+                self.assertEqual(len(data[label][self.field][i]), num_exports)
+                for f in data[label][self.field][i]:
+                    self.assertTrue(isinstance(f, Function))
+
+    def test_data_by_subinterval(self):
+        data = self.solution_data.data_by_subinterval
+        self.assertTrue(isinstance(data, list))
+        self.assertEqual(len(data), self.num_subintervals)
+        for i, sub_data in enumerate(data):
+            self.assertTrue(isinstance(sub_data, AttrDict))
+            self.assertTrue(self.field in sub_data)
+            self.assertTrue(isinstance(sub_data[self.field], AttrDict))
+            for label in self.labels:
+                self.assertTrue(label in sub_data[self.field])
+                self.assertTrue(isinstance(sub_data[self.field][label], list))
+                self.assertEqual(len(sub_data[self.field][label]), self.num_exports[i])
+                for f in sub_data[self.field][label]:
+                    self.assertTrue(isinstance(f, Function))

--- a/test/test_function_data.py
+++ b/test/test_function_data.py
@@ -4,7 +4,6 @@ Unit tests for :class:`~.FunctionData` and its subclasses.
 from firedrake import *
 from goalie import *
 import abc
-from parameterized import parameterized
 import unittest
 
 
@@ -133,9 +132,7 @@ class TestIndicatorData(BaseTestCases.TestFunctionData):
             self.time_partition, [self.mesh for _ in range(self.num_subintervals)]
         )
 
-    @parameterized.expand([["field"], ["label"]])
-    def test_extract_by_layout(self, layout):
-        data = self.solution_data.extract(layout=layout)
+    def _test_extract_by_field_or_label(self, data):
         self.assertTrue(isinstance(data, AttrDict))
         self.assertTrue(self.field in data)
         self.assertEqual(len(data[self.field]), self.num_subintervals)
@@ -144,6 +141,14 @@ class TestIndicatorData(BaseTestCases.TestFunctionData):
             self.assertEqual(len(data[self.field][i]), num_exports)
             for f in data[self.field][i]:
                 self.assertTrue(isinstance(f, Function))
+
+    def test_extract_by_field(self):
+        data = self.solution_data.extract(layout="field")
+        self._test_extract_by_field_or_label(data)
+
+    def test_extract_by_label(self):
+        data = self.solution_data.extract(layout="label")
+        self._test_extract_by_field_or_label(data)
 
     def test_extract_by_subinterval(self):
         data = self.solution_data.extract(layout="subinterval")

--- a/test/test_function_data.py
+++ b/test/test_function_data.py
@@ -3,78 +3,119 @@ Unit tests for :class:`~.FunctionData` and its subclasses.
 """
 from firedrake import *
 from goalie import *
+import abc
 import unittest
 
 
-class TestForwardSolutionData(unittest.TestCase):
+class BaseTestCases:
+    """
+    Class containing abstract base classes for unit testing subclasses of
+    :class:`~.FunctionData`.
+    """
+
+    class TestFunctionData(unittest.TestCase, abc.ABC):
+        """
+        Base class for unit testing subclasses of :class:`~.FunctionData`.
+        """
+
+        def setUp(self):
+            end_time = 1.0
+            self.num_subintervals = 2
+            timesteps = [0.5, 0.25]
+            self.field = "field"
+            self.num_exports = [1, 2]
+            mesh = UnitTriangleMesh()
+            self.time_partition = TimePartition(
+                end_time, self.num_subintervals, timesteps, self.field
+            )
+            self.function_spaces = {
+                self.field: [
+                    FunctionSpace(mesh, "DG", 0) for _ in range(self.num_subintervals)
+                ]
+            }
+            self._create_solution_data()
+
+        @abc.abstractmethod
+        def _create_solution_data(self):
+            pass
+
+        def test_data_by_field(self):
+            data = self.solution_data.data_by_field
+            self.assertTrue(isinstance(data, AttrDict))
+            self.assertTrue(self.field in data)
+            for label in self.labels:
+                self.assertTrue(isinstance(data[self.field], AttrDict))
+                self.assertTrue(label in data[self.field])
+                self.assertTrue(isinstance(data[self.field][label], list))
+                self.assertEqual(len(data[self.field][label]), self.num_subintervals)
+                for i, num_exports in enumerate(self.num_exports):
+                    self.assertTrue(isinstance(data[self.field][label][i], list))
+                    self.assertEqual(len(data[self.field][label][i]), num_exports)
+                    for f in data[self.field][label][i]:
+                        self.assertTrue(isinstance(f, Function))
+
+        def test_data_by_label(self):
+            data = self.solution_data.data_by_label
+            self.assertTrue(isinstance(data, AttrDict))
+            for label in self.labels:
+                self.assertTrue(label in data)
+                self.assertTrue(isinstance(data[label], AttrDict))
+                self.assertTrue(self.field in data[label])
+                self.assertTrue(isinstance(data[label][self.field], list))
+                self.assertEqual(len(data[label][self.field]), self.num_subintervals)
+                for i, num_exports in enumerate(self.num_exports):
+                    self.assertTrue(isinstance(data[label][self.field][i], list))
+                    self.assertEqual(len(data[label][self.field][i]), num_exports)
+                    for f in data[label][self.field][i]:
+                        self.assertTrue(isinstance(f, Function))
+
+        def test_data_by_subinterval(self):
+            data = self.solution_data.data_by_subinterval
+            self.assertTrue(isinstance(data, list))
+            self.assertEqual(len(data), self.num_subintervals)
+            for i, sub_data in enumerate(data):
+                self.assertTrue(isinstance(sub_data, AttrDict))
+                self.assertTrue(self.field in sub_data)
+                self.assertTrue(isinstance(sub_data[self.field], AttrDict))
+                for label in self.labels:
+                    self.assertTrue(label in sub_data[self.field])
+                    self.assertTrue(isinstance(sub_data[self.field][label], list))
+                    self.assertEqual(
+                        len(sub_data[self.field][label]), self.num_exports[i]
+                    )
+                    for f in sub_data[self.field][label]:
+                        self.assertTrue(isinstance(f, Function))
+
+
+class TestForwardSolutionData(BaseTestCases.TestFunctionData):
     """
     Unit tests for :class:`~.ForwardSolutionData`.
     """
 
     def setUp(self):
-        end_time = 1.0
-        self.num_subintervals = 2
-        timesteps = [0.5, 0.25]
-        self.field = "field"
+        super().setUp()
         self.labels = ("forward", "forward_old")
-        self.num_exports = [1, 2]
-        mesh = UnitTriangleMesh()
-        self.time_partition = TimePartition(
-            end_time, self.num_subintervals, timesteps, self.field
-        )
-        self.function_spaces = {
-            self.field: [
-                FunctionSpace(mesh, "DG", 0) for _ in range(self.num_subintervals)
-            ]
-        }
-        self._create_solution_data()
 
     def _create_solution_data(self):
         self.solution_data = ForwardSolutionData(
             self.time_partition, self.function_spaces
         )
 
-    def test_data_by_field(self):
-        data = self.solution_data.data_by_field
-        self.assertTrue(isinstance(data, AttrDict))
-        self.assertTrue(self.field in data)
-        for label in self.labels:
-            self.assertTrue(isinstance(data[self.field], AttrDict))
-            self.assertTrue(label in data[self.field])
-            self.assertTrue(isinstance(data[self.field][label], list))
-            self.assertEqual(len(data[self.field][label]), self.num_subintervals)
-            for i, num_exports in enumerate(self.num_exports):
-                self.assertTrue(isinstance(data[self.field][label][i], list))
-                self.assertEqual(len(data[self.field][label][i]), num_exports)
-                for f in data[self.field][label][i]:
-                    self.assertTrue(isinstance(f, Function))
 
-    def test_data_by_label(self):
-        data = self.solution_data.data_by_label
-        self.assertTrue(isinstance(data, AttrDict))
-        for label in self.labels:
-            self.assertTrue(label in data)
-            self.assertTrue(isinstance(data[label], AttrDict))
-            self.assertTrue(self.field in data[label])
-            self.assertTrue(isinstance(data[label][self.field], list))
-            self.assertEqual(len(data[label][self.field]), self.num_subintervals)
-            for i, num_exports in enumerate(self.num_exports):
-                self.assertTrue(isinstance(data[label][self.field][i], list))
-                self.assertEqual(len(data[label][self.field][i]), num_exports)
-                for f in data[label][self.field][i]:
-                    self.assertTrue(isinstance(f, Function))
+class TestAdjointSolutionData(BaseTestCases.TestFunctionData):
+    """
+    Unit tests for :class:`~.AdjointSolutionData`.
+    """
 
-    def test_data_by_subinterval(self):
-        data = self.solution_data.data_by_subinterval
-        self.assertTrue(isinstance(data, list))
-        self.assertEqual(len(data), self.num_subintervals)
-        for i, sub_data in enumerate(data):
-            self.assertTrue(isinstance(sub_data, AttrDict))
-            self.assertTrue(self.field in sub_data)
-            self.assertTrue(isinstance(sub_data[self.field], AttrDict))
-            for label in self.labels:
-                self.assertTrue(label in sub_data[self.field])
-                self.assertTrue(isinstance(sub_data[self.field][label], list))
-                self.assertEqual(len(sub_data[self.field][label]), self.num_exports[i])
-                for f in sub_data[self.field][label]:
-                    self.assertTrue(isinstance(f, Function))
+    def setUp(self):
+        super().setUp()
+        self.labels = ("forward", "forward_old", "adjoint", "adjoint_next")
+
+    def _create_solution_data(self):
+        self.solution_data = AdjointSolutionData(
+            self.time_partition, self.function_spaces
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_function_data.py
+++ b/test/test_function_data.py
@@ -4,6 +4,7 @@ Unit tests for :class:`~.FunctionData` and its subclasses.
 from firedrake import *
 from goalie import *
 import abc
+from parameterized import parameterized
 import unittest
 
 
@@ -40,8 +41,8 @@ class BaseTestCases:
         def _create_function_data(self):
             pass
 
-        def test_data_by_field(self):
-            data = self.solution_data._data_by_field
+        def test_extract_by_field(self):
+            data = self.solution_data.extract(layout="field")
             self.assertTrue(isinstance(data, AttrDict))
             self.assertTrue(self.field in data)
             for label in self.labels:
@@ -55,8 +56,8 @@ class BaseTestCases:
                     for f in data[self.field][label][i]:
                         self.assertTrue(isinstance(f, Function))
 
-        def test_data_by_label(self):
-            data = self.solution_data._data_by_label
+        def test_extract_by_label(self):
+            data = self.solution_data.extract(layout="label")
             self.assertTrue(isinstance(data, AttrDict))
             for label in self.labels:
                 self.assertTrue(label in data)
@@ -70,8 +71,8 @@ class BaseTestCases:
                     for f in data[label][self.field][i]:
                         self.assertTrue(isinstance(f, Function))
 
-        def test_data_by_subinterval(self):
-            data = self.solution_data._data_by_subinterval
+        def test_extract_by_subinterval(self):
+            data = self.solution_data.extract(layout="subinterval")
             self.assertTrue(isinstance(data, list))
             self.assertEqual(len(data), self.num_subintervals)
             for i, sub_data in enumerate(data):
@@ -132,11 +133,9 @@ class TestIndicatorData(BaseTestCases.TestFunctionData):
             self.time_partition, [self.mesh for _ in range(self.num_subintervals)]
         )
 
-    def _test_data_by_field_or_label(self, field_or_data):
-        if field_or_data == "field":
-            data = self.solution_data._data_by_field
-        else:
-            data = self.solution_data._data_by_label
+    @parameterized.expand([["field"], ["label"]])
+    def test_extract_by_layout(self, layout):
+        data = self.solution_data.extract(layout=layout)
         self.assertTrue(isinstance(data, AttrDict))
         self.assertTrue(self.field in data)
         self.assertEqual(len(data[self.field]), self.num_subintervals)
@@ -146,14 +145,8 @@ class TestIndicatorData(BaseTestCases.TestFunctionData):
             for f in data[self.field][i]:
                 self.assertTrue(isinstance(f, Function))
 
-    def test_data_by_field(self):
-        self._test_data_by_field_or_label("field")
-
-    def test_data_by_label(self):
-        self._test_data_by_field_or_label("label")
-
-    def test_data_by_subinterval(self):
-        data = self.solution_data._data_by_subinterval
+    def test_extract_by_subinterval(self):
+        data = self.solution_data.extract(layout="subinterval")
         self.assertTrue(isinstance(data, list))
         self.assertEqual(len(data), self.num_subintervals)
         for i, sub_data in enumerate(data):


### PR DESCRIPTION
Partially addresses #26.

This PR does several things:
* Simplifies the API for `FunctionData` and its subclasses.
* Implements unit tests to get 100% code coverage for `function_data.py`.
* Implements access by label.
* Implements access by subinterval.