### PR TITLE
Purge typehints; mention type in docstrings

### DIFF
--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -125,12 +125,22 @@ class AdjointMeshSeq(MeshSeq):
         corresponding to either an end time or time integrated quantity of interest,
         respectively. If the QoI has an argument then it is for the current time.
 
+        Signature for the function to be returned:
+        ```
+        :arg t: the current time (for time-integrated QoIs)
+        :type t: :class:`float`
+        :return: the QoI as a 0-form
+        :rtype: :class:`ufl.form.Form`
+        ```
+
         :arg solution_map: a dictionary whose keys are the solution field names and whose
             values are the corresponding solutions
         :type solution_map: :class:`dict` with :class:`str` keys and values and
             :class:`firedrake.function.Function` values
         :arg subinterval: the subinterval index
         :type subinterval: :class:`int`
+        :returns: the function for obtaining the QoI
+        :rtype: see docstring above
         """
         if self._get_qoi is None:
             raise NotImplementedError("'get_qoi' is not implemented.")

--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -237,8 +237,8 @@ class AdjointMeshSeq(MeshSeq):
         :returns: the solution data of the forward and adjoint solves
         :rtype: :class:`~.AdjointSolutionData`
         """
-        # TODO: Separate out qoi_kwargs
-        # TODO: Support get_adj_values in AdjointSolutionData
+        # TODO #125: Support get_adj_values in AdjointSolutionData
+        # TODO #126: Separate out qoi_kwargs
         P = self.time_partition
         num_subintervals = len(self)
         solver = self.solver

--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -15,10 +15,10 @@ from functools import wraps
 import numpy as np
 
 
-__all__ = ["AdjointMeshSeq"]
+__all__ = ["AdjointMeshSeq", "annotate_qoi"]
 
 
-def _annotate_qoi(get_qoi):
+def annotate_qoi(get_qoi):
     """
     Decorator that ensures QoIs are annotated properly.
 
@@ -118,7 +118,7 @@ class AdjointMeshSeq(MeshSeq):
     def initial_condition(self):
         return super().initial_condition
 
-    @_annotate_qoi
+    @annotate_qoi
     def get_qoi(self, solution_map, subinterval):
         r"""
         Get the function for evaluating the QoI, which has either zero or one arguments,

--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -282,17 +282,14 @@ class AdjointMeshSeq(MeshSeq):
 
             All keyword arguments are passed to the solver.
             """
-            self._controls = list(initial_condition_map.values())
-            return solver(
-                subinterval,
-                AttrDict(
-                    {
-                        field: pyadjoint.Control(ic.copy(deepcopy=True))
-                        for field, ic in initial_condition_map.items()
-                    }
-                ),
-                **kwargs,
+            copy_map = AttrDict(
+                {
+                    field: initial_condition.copy(deepcopy=True)
+                    for field, initial_condition in initial_condition_map.items()
+                }
             )
+            self._controls = list(map(pyadjoint.Control, copy_map.values()))
+            return solver(subinterval, copy_map, **kwargs)
 
         # Loop over subintervals in reverse
         seeds = {}

--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -120,14 +120,15 @@ class AdjointMeshSeq(MeshSeq):
 
     @annotate_qoi
     def get_qoi(self, solution_map, subinterval):
-        r"""
+        """
         Get the function for evaluating the QoI, which has either zero or one arguments,
         corresponding to either an end time or time integrated quantity of interest,
         respectively. If the QoI has an argument then it is for the current time.
 
         :arg solution_map: a dictionary whose keys are the solution field names and whose
-            values are the corresponding solution :class:`firedrake.function.Function`\s
-        :type solution_map: :class:`dict`
+            values are the corresponding solutions
+        :type solution_map: :class:`dict` with :class:`str` keys and values and
+            :class:`firedrake.function.Function` values
         :arg subinterval: the subinterval index
         :type subinterval: :class:`int`
         """
@@ -145,7 +146,8 @@ class AdjointMeshSeq(MeshSeq):
         The QoI is also evaluated.
 
         :kwarg solver_kwargs: additional keyword arguments to be passed to the solver
-        :type solver_kwargs: :class:`dict`
+        :type solver_kwargs: :class:`dict` with :class:`str` keys and values which may
+            take various types
         :kwarg run_final_subinterval: if ``True``, the solver is run on the final
             subinterval
         :type run_final_subinterval: :class:`bool`
@@ -228,7 +230,8 @@ class AdjointMeshSeq(MeshSeq):
         :type solver_kwargs: :class:`dict` with :class:`str` keys and values which may
             take various types
         :kwarg adj_solver_kwargs: parameters for the adjoint solver
-        :type adj_solver_kwargs: :class:`dict`
+        :type adj_solver_kwargs: :class:`dict` with :class:`str` keys and values which
+            may take various types
         :kwarg get_adj_values: if ``True``, adjoint actions are also returned at exported
             timesteps
         :type get_adj_values: :class:`bool`
@@ -270,15 +273,15 @@ class AdjointMeshSeq(MeshSeq):
         @PETSc.Log.EventDecorator("goalie.AdjointMeshSeq.solve_adjoint.evaluate_fwd")
         @wraps(solver)
         def wrapped_solver(subinterval, initial_condition_map, **kwargs):
-            r"""
+            """
             Decorator to allow the solver to stash its initial conditions as controls.
 
             :arg subinterval: the subinterval index
             :type subinterval: :class:`int`
             :arg initial_condition_map: a dictionary of initial conditions, keyed by
                 field name
-            :type initial_condition_map: :class:`dict` whose keys are :class:`str`\s
-                and whose values are :class:`firedrake.function.Function`\s
+            :type initial_condition_map: :class:`dict` with :class:`str` keys and
+                :class:`firedrake.function.Function` values
 
             All keyword arguments are passed to the solver.
             """

--- a/goalie/error_estimation.py
+++ b/goalie/error_estimation.py
@@ -6,14 +6,13 @@ from firedrake import Function, FunctionSpace
 from firedrake.functionspaceimpl import WithGeometry
 from firedrake.petsc import PETSc
 import ufl
-from typing import Dict, Optional, Union
 
 
 __all__ = ["get_dwr_indicator"]
 
 
 @PETSc.Log.EventDecorator()
-def form2indicator(F: ufl.form.Form) -> Function:
+def form2indicator(F):
     r"""
     Given a 0-form, multiply the integrand of each of its integrals by a
     :math:`\mathbb P0` test function and reassemble to give an element-wise error
@@ -23,7 +22,9 @@ def form2indicator(F: ufl.form.Form) -> Function:
     or :class:`firedrake.ufl_expr.TrialFunction`\s.
 
     :arg F: the 0-form
+    :type F: :class:`ufl.form.Form`
     :return: the corresponding error indicator field
+    :rtype: `firedrake.function.Function`
     """
     if not isinstance(F, ufl.form.Form):
         raise TypeError(f"Expected 'F' to be a Form, not '{type(F)}'.")
@@ -59,9 +60,7 @@ def form2indicator(F: ufl.form.Form) -> Function:
 
 
 @PETSc.Log.EventDecorator()
-def get_dwr_indicator(
-    F, adjoint_error: Function, test_space: Optional[Union[WithGeometry, Dict]] = None
-) -> Function:
+def get_dwr_indicator(F, adjoint_error, test_space=None):
     r"""
     Given a 1-form and an approximation of the error in the adjoint solution, compute a
     dual weighted residual (DWR) error indicator.
@@ -73,11 +72,17 @@ def get_dwr_indicator(
     :class:`firedrake.ufl_expr.TrialFunction`\s.
 
     :arg F: the form
-    :arg adjoint_error: the approximation to the adjoint error, either as a single
-        :class:`firedrake.function.Function`, or in a dictionary
-    :kwarg test_space: the
-        :class:`firedrake.functionspaceimpl.WithGeometry` that the test function lives
-        in, or an appropriate dictionary
+    :type F: :class:`ufl.form.Form`
+    :arg adjoint_error: a dictionary whose keys are field names and whose values are the
+        approximations to the corresponding components of the adjoint error, or a single
+        such component
+    :type adjoint_error: :class:`dict` or :class:`firedrake.function.Function`
+    :kwarg test_space: a dictionary whose keys are field names and whose values are the
+        test spaces for the corresponding fields, or a single such test space (or
+        ``None`` to determine the test space(s) automatically)
+    :type test_space: :class:`firedrake.functionspaceimpl.WithGeometry`
+    :returns: the DWR indicator
+    :rtype: :class:`firedrake.function.Function`
     """
     mapping = {}
     if not isinstance(F, ufl.form.Form):

--- a/goalie/error_estimation.py
+++ b/goalie/error_estimation.py
@@ -76,7 +76,8 @@ def get_dwr_indicator(F, adjoint_error, test_space=None):
     :arg adjoint_error: a dictionary whose keys are field names and whose values are the
         approximations to the corresponding components of the adjoint error, or a single
         such component
-    :type adjoint_error: :class:`dict` or :class:`firedrake.function.Function`
+    :type adjoint_error: :class:`firedrake.function.Function` or :class:`dict` with
+        :class:`str` keys and :class:`firedrake.function.Function` values
     :kwarg test_space: a dictionary whose keys are field names and whose values are the
         test spaces for the corresponding fields, or a single such test space (or
         ``None`` to determine the test space(s) automatically)

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -78,6 +78,12 @@ class SolutionData(FunctionData, abc.ABC):
 class ForwardSolutionData(SolutionData):
     """
     Class representing solution data for general forward problems.
+
+    For a given exported timestep, the field types are:
+
+    * ``'forward'``: the forward solution after taking the timestep;
+    * ``'forward_old'``: the forward solution before taking the timestep (provided
+      the problem is not steady-state).
     """
 
     def __init__(self, *args, **kwargs):
@@ -88,6 +94,15 @@ class ForwardSolutionData(SolutionData):
 class AdjointSolutionData(SolutionData):
     """
     Class representing solution data for general adjoint problems.
+
+    For a given exported timestep, the field types are:
+
+    * ``'forward'``: the forward solution after taking the timestep;
+    * ``'forward_old'``: the forward solution before taking the timestep (provided
+      the problem is not steady-state)
+    * ``'adjoint'``: the adjoint solution after taking the timestep;
+    * ``'adjoint_next'``: the adjoint solution before taking the timestep
+      backwards (provided the problem is not steady-state).
     """
 
     def __init__(self, *args, **kwargs):

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -302,7 +302,8 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
         :rtype1: :class:`~.AdjointSolutionData
         :rtype2: :class:`~.IndicatorData
         """
-        # TODO: adaptor no longer needs solution and indicator data to be passed explicitly
+        # TODO #124: adaptor no longer needs solution and indicator data to be passed
+        #            explicitly
         self.element_counts = [self.count_elements()]
         self.vertex_counts = [self.count_vertices()]
         self.qoi_values = []
@@ -324,9 +325,8 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             )
 
             # Check for QoI convergence
-            # TODO: Put this check inside the adjoint solve as
-            #       an optional return condition so that we
-            #       can avoid unnecessary extra solves
+            # TODO #23: Put this check inside the adjoint solve as an optional return
+            #           condition so that we can avoid unnecessary extra solves
             self.qoi_values.append(self.J)
             qoi_converged = self.check_qoi_convergence()
             if self.params.convergence_criteria == "any" and qoi_converged:

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -131,7 +131,8 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
         :kwarg enrichment_kwargs: keyword arguments to pass to the global enrichment
             method - see :meth:`~.GoalOrientedMeshSeq.get_enriched_mesh_seq` for the
             supported enrichment methods and options
-        :type enrichment_kwargs: :class:`dict`
+        :type enrichment_kwargs: :class:`dict` with :class:`str` keys and values which
+            may take various types
         :kwarg solver_kwargs: parameters for the forward solver, as well as any
             parameters for the QoI, which should be included as a sub-dictionary with key
             'qoi_kwargs'
@@ -290,11 +291,14 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             iteration
         :kwarg enrichment_kwargs: keyword arguments to pass to the global enrichment
             method
-        :type enrichment_kwargs: :class:`dict`
+        :type enrichment_kwargs: :class:`dict` with :class:`str` keys and values which
+            may take various types
         :kwarg solver_kwargs: parameters to pass to the solver
-        :type solver_kwargs: :class:`dict`
+        :type solver_kwargs: :class:`dict` with :class:`str` keys and values which may
+            take various types
         :kwarg adaptor_kwargs: parameters to pass to the adaptor
-        :type adaptor_kwargs: :class:`dict`
+        :type adaptor_kwargs: :class:`dict` with :class:`str` keys and values which may
+            take various types
         :kwarg indicator_fn: function which maps the form, adjoint error and enriched
             space(s) as arguments to the error indicator
             :class:`firedrake.function.Function`

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -6,12 +6,10 @@ from .adjoint import AdjointMeshSeq
 from .error_estimation import get_dwr_indicator
 from .function_data import IndicatorData
 from .log import pyrint
-from .utility import AttrDict
 from firedrake import Function, FunctionSpace, MeshHierarchy, TransferManager, project
 from firedrake.petsc import PETSc
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 import numpy as np
-from typing import Tuple
 import ufl
 
 
@@ -28,18 +26,22 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
         self.estimator_values = []
 
     @PETSc.Log.EventDecorator()
-    def get_enriched_mesh_seq(
-        self, enrichment_method: str = "p", num_enrichments: int = 1
-    ) -> AdjointMeshSeq:
+    def get_enriched_mesh_seq(self, enrichment_method="p", num_enrichments=1):
         """
         Construct a sequence of globally enriched spaces.
 
-        Currently, global enrichment may be achieved using one of:
-        * h-refinement (``enrichment_method = 'h'``);
-        * p-refinement (``enrichment_method = 'p'``).
+        The following global enrichment methods are supported:
+        * h-refinement (``enrichment_method='h'``) - refine each mesh element
+          uniformly in each direction;
+        * p-refinement (``enrichment_method='p'``) - increase the function space
+          polynomial order by one globally.
 
-        The number of refinements may be controlled by the keyword argument
-        ``num_enrichments``.
+        :kwarg enrichment_method: the method for enriching the mesh sequence
+        :type enrichment_method: :class:`str`
+        :kwarg num_enrichments: the number of enrichments to apply
+        :type num_enrichments: :class:`int`
+        :returns: the enriched mesh sequence
+        :type: the type is inherited from the parent mesh sequence
         """
         if enrichment_method not in ("h", "p"):
             raise ValueError(f"Enrichment method '{enrichment_method}' not supported.")
@@ -57,7 +59,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             meshes = self.meshes
 
         # Construct object to hold enriched spaces
-        enriched_mesh_seq = self.__class__(
+        enriched_mesh_seq = type(self)(
             self.time_partition,
             meshes,
             get_function_spaces=self._get_function_spaces,
@@ -87,18 +89,32 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
 
     @staticmethod
     def _get_transfer_function(enrichment_method):
+        """
+        Get the function for transferring function data between a mesh sequence and its
+        enriched counterpart.
+
+        :arg enrichment_method: the enrichment method used to generate the counterpart
+            - see :meth:`~.GoalOrientedMeshSeq.get_enriched_mesh_seq` for the supported
+            enrichment methods
+        :type enrichment_method: :class:`str`
+        :returns: the function for mapping function data between mesh sequences
+        """
         if enrichment_method == "h":
             return TransferManager().prolong
         else:
             return lambda source, target: target.interpolate(source)
 
     def _create_indicators(self):
+        """
+        Create the :class:`~.FunctionData` instance for holding error indicator data.
+        """
         self._indicators = IndicatorData(self.time_partition, self.meshes)
 
     @property
     def indicators(self):
         """
-        Arrays holding exported error indicators.
+        :returns: the error indicator data object
+        :rtype: :class:`~.IndicatorData`
         """
         if not hasattr(self, "_indicators"):
             self._create_indicators()
@@ -106,20 +122,27 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
 
     @PETSc.Log.EventDecorator()
     def indicate_errors(
-        self,
-        enrichment_kwargs: dict = {},
-        adj_kwargs: dict = {},
-        indicator_fn: Callable = get_dwr_indicator,
-    ) -> Tuple[dict, AttrDict]:
+        self, enrichment_kwargs={}, solver_kwargs={}, indicator_fn=get_dwr_indicator
+    ):
         """
         Compute goal-oriented error indicators for each subinterval based on solving the
         adjoint problem in a globally enriched space.
 
         :kwarg enrichment_kwargs: keyword arguments to pass to the global enrichment
-            method
-        :kwarg adj_kwargs: keyword arguments to pass to the adjoint solver
-        :kwarg indicator_fn: function for error indication, which takes the form,
-            adjoint error and enriched space(s) as arguments
+            method - see :meth:`~.GoalOrientedMeshSeq.get_enriched_mesh_seq` for the
+            supported enrichment methods and options
+        :type enrichment_kwargs: :class:`dict`
+        :kwarg solver_kwargs: parameters for the forward solver, as well as any
+            parameters for the QoI, which should be included as a sub-dictionary with key
+            'qoi_kwargs'
+        :type solver_kwargs: :class:`dict` with :class:`str` keys and values which may
+            take various types
+        :kwarg indicator_fn: function which maps the form, adjoint error and enriched
+            space(s) as arguments to the error indicator
+            :class:`firedrake.function.Function`
+        :returns: solution and indicator data objects
+        :rtype1: :class:`~.AdjointSolutionData
+        :rtype2: :class:`~.IndicatorData
         """
         enrichment_kwargs.setdefault("enrichment_method", "p")
         enrichment_kwargs.setdefault("num_enrichments", 1)
@@ -127,8 +150,8 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
         transfer = self._get_transfer_function(enrichment_kwargs["enrichment_method"])
 
         # Solve the forward and adjoint problems on the MeshSeq and its enriched version
-        self.solve_adjoint(**adj_kwargs)
-        enriched_mesh_seq.solve_adjoint(**adj_kwargs)
+        self.solve_adjoint(**solver_kwargs)
+        enriched_mesh_seq.solve_adjoint(**solver_kwargs)
 
         FWD, ADJ = "forward", "adjoint"
         FWD_OLD = "forward" if self.steady else "forward_old"
@@ -189,12 +212,15 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
         return self.solutions, self.indicators
 
     @PETSc.Log.EventDecorator()
-    def error_estimate(self, absolute_value: bool = False) -> float:
+    def error_estimate(self, absolute_value=False):
         r"""
-        Deduce the error estimator value associated with error indicator fields defined over
-        a :class:`~.MeshSeq`.
+        Deduce the error estimator value associated with error indicator fields defined
+        over the mesh sequence.
 
-        :kwarg absolute_value: toggle whether to take the modulus on each element
+        :kwarg absolute_value: if ``True``, the modulus is taken on each element
+        :type absolute_value: :class:`bool`
+        :returns: the error estimator value
+        :rtype: :class:`float`
         """
         assert isinstance(self.indicators, IndicatorData)
         if not isinstance(absolute_value, bool):
@@ -224,6 +250,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
         difference in error estimator value being smaller than the specified tolerance.
 
         :return: ``True`` if estimator convergence is detected, else ``False``
+        :rtype: :class:`bool`
         """
         if not self.check_convergence.any():
             self.info(
@@ -244,32 +271,38 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
     @PETSc.Log.EventDecorator()
     def fixed_point_iteration(
         self,
-        adaptor: Callable,
-        enrichment_kwargs: dict = {},
-        adaptor_kwargs: dict = {},
-        adj_kwargs: dict = {},
-        indicator_fn: Callable = get_dwr_indicator,
-        **kwargs,
+        adaptor,
+        update_params=None,
+        enrichment_kwargs={},
+        adaptor_kwargs={},
+        solver_kwargs={},
+        indicator_fn=get_dwr_indicator,
     ):
         r"""
-        Apply goal-oriented mesh adaptation using a fixed point iteration loop.
+        Apply goal-oriented mesh adaptation using a fixed point iteration loop approach.
 
-        :arg adaptor: function for adapting the mesh sequence. Its arguments are the
-            :class:`~.MeshSeq` instance, the dictionary of solution
-            :class:`firedrake.function.Function`\s and the list of error indicators.
-            It should return ``True`` if the convergence criteria checks are to be
-            skipped for this iteration. Otherwise, it should return ``False``.
-        :kwarg update_params: function for updating :attr:`~.GoalOrientedMeshSeq.params`
-            at each iteration. Its arguments are the parameter class and the fixed point
-            iteration number
+        :arg adaptor: function for adapting the mesh sequence. Its arguments are the mesh
+            sequence and the solution and indicator data objects. It should return
+            ``True`` if the convergence criteria checks are to be skipped for this
+            iteration. Otherwise, it should return ``False``.
+        :kwarg update_params: function for updating :attr:`~.MeshSeq.params` at each
+            iteration. Its arguments are the parameter class and the fixed point
+            iteration
         :kwarg enrichment_kwargs: keyword arguments to pass to the global enrichment
             method
-        :kwarg adaptor_kwargs: a dictionary providing parameters to the adaptor
-        :kwarg adj_kwargs: keyword arguments to pass to the adjoint solver
-        :kwarg indicator_fn: function for error indication, which takes the form, adjoint
-            error and enriched space(s) as arguments
+        :type enrichment_kwargs: :class:`dict`
+        :kwarg solver_kwargs: parameters to pass to the solver
+        :type solver_kwargs: :class:`dict`
+        :kwarg adaptor_kwargs: parameters to pass to the adaptor
+        :type adaptor_kwargs: :class:`dict`
+        :kwarg indicator_fn: function which maps the form, adjoint error and enriched
+            space(s) as arguments to the error indicator
+            :class:`firedrake.function.Function`
+        :returns: solution and indicator data objects
+        :rtype1: :class:`~.AdjointSolutionData
+        :rtype2: :class:`~.IndicatorData
         """
-        update_params = kwargs.get("update_params")
+        # TODO: adaptor no longer needs solution and indicator data to be passed explicitly
         self.element_counts = [self.count_elements()]
         self.vertex_counts = [self.count_vertices()]
         self.qoi_values = []
@@ -286,7 +319,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             self._create_indicators()
             self.indicate_errors(
                 enrichment_kwargs=enrichment_kwargs,
-                adj_kwargs=adj_kwargs,
+                solver_kwargs=solver_kwargs,
                 indicator_fn=indicator_fn,
             )
 

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -71,7 +71,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
             qoi_type=self.qoi_type,
             parameters=self.params,
         )
-        enriched_mesh_seq.update_function_spaces()
+        enriched_mesh_seq._update_function_spaces()
 
         # Apply p-refinement
         if enrichment_method == "p":

--- a/goalie/interpolation.py
+++ b/goalie/interpolation.py
@@ -19,11 +19,15 @@ def project(source, target_space, **kwargs):
 
     Extra keyword arguments are passed to :func:`firedrake.projection.project`.
 
-    :arg source: the :class:`firedrake.function.Function` or
-        :class:`firedrake.cofunction.Cofunction` to be projected
-    :arg target_space: the :class:`firedrake.functionspaceimpl.FunctionSpace` which we
-        seek to project into, or the :class:`firedrake.function.Function` or
-        :class:`firedrake.cofunction.Cofunction` to use as the target
+    :arg source: the function to be projected
+    :type source: :class:`firedrake.function.Function` or
+        :class:`firedrake.cofunction.Cofunction`
+    :arg target_space: the function space which we seek to project into, or the function
+        or cofunction to use as the target
+    :type target_space: :class:`firedrake.functionspaceimpl.FunctionSpace`,
+        :class:`firedrake.function.Function`, or :class:`firedrake.cofunction.Cofunction`
+    :returns: the projection
+    :rtype: :class:`firedrake.function.Function`
     """
     if not isinstance(source, (firedrake.Function, firedrake.Cofunction)):
         raise NotImplementedError(
@@ -45,20 +49,22 @@ def project(source, target_space, **kwargs):
         return _project(source, target, **kwargs)
 
 
-@PETSc.Log.EventDecorator("goalie.interpolation.project")
+@PETSc.Log.EventDecorator()
 def _project(source, target, **kwargs):
     """
-    Apply a mesh-to-mesh conservative projection to some source
-    :class:`firedrake.function.Function`, mapping to a target
-    :class:`firedrake.function.Function`.
+    Apply mesh-to-mesh conservative projection.
 
-    This function extends to the case of mixed spaces.
+    This function extends :func:`firedrake.projection.project`` to account for mixed
+    spaces.
 
-    Extra keyword arguments are passed to Firedrake's
-    :func:`firedrake.projection.project`` function.
+    :arg source: the Function to be projected
+    :type source: :class:`firedrake.function.Function`
+    :arg target: the Function which we seek to project onto
+    :type target: :class:`firedrake.function.Function`.
+    :returns: the target projection
+    :rtype: :class:`firedrake.function.Function`
 
-    :arg source: the `Function` to be projected
-    :arg target: the `Function` which we seek to project onto
+    Extra keyword arguments are passed to :func:`firedrake.projection.project``.
     """
     Vs = source.function_space()
     Vt = target.function_space()
@@ -85,23 +91,23 @@ def _project(source, target, **kwargs):
     return target
 
 
-@PETSc.Log.EventDecorator("goalie.interpolation.project_adjoint")
+@PETSc.Log.EventDecorator()
 def _project_adjoint(target_b, source_b, **kwargs):
     """
-    Apply the adjoint of a mesh-to-mesh conservative projection to some seed
-    :class:`firedrake.cofunction.Cofunction`, mapping to an output
-    :class:`firedrake.cofunction.Cofunction`.
+    Apply an adjoint mesh-to-mesh conservative projection.
 
     The notation used here is in terms of the adjoint of standard projection.
     However, this function may also be interpreted as a projector in its own right,
     mapping ``target_b`` to ``source_b``.
 
-    Extra keyword arguments are passed to :func:`firedrake.projection.project`.
+    :arg target_b: seed cofunction from the target space of the forward projection
+    :type target_b: :class:`firedrake.cofunction.Cofunction`
+    :arg source_b: output cofunction from the source space of the forward projection
+    :type source_b: :class:`firedrake.cofunction.Cofunction`.
+    :returns: the adjoint projection
+    :rtype: :class:`firedrake.cofunction.Cofunction`
 
-    :arg target_b: seed :class:`firedrake.cofunction.Cofunction` from the target space
-        of the forward projection
-    :arg source_b: the :class:`firedrake.cofunction.Cofunction` from the source space
-        of the forward projection
+    Extra keyword arguments are passed to :func:`firedrake.projection.project`.
     """
     from firedrake.supermeshing import assemble_mixed_mass_matrix
 

--- a/goalie/log.py
+++ b/goalie/log.py
@@ -25,9 +25,15 @@ __all__ = [
 ]
 
 
-def get_new_logger(
-    name: str, fmt: str = "%(levelname)s %(message)s"
-) -> logging.StreamHandler:
+def get_new_logger(name, fmt="%(levelname)s %(message)s"):
+    """
+    :arg name: the name for the logger
+    :type name: :class:`str`
+    :kwarg fmt: format string to use
+    :type fmt: :class:`str`
+    :returns: logger instance
+    :rtype: :class:`logging.StreamHandler`
+    """
     logger = logging.getLogger(name)
     for handler in logger.handlers:
         logger.removeHandler(handler)

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -268,7 +268,18 @@ class MeshSeq:
         dictionary containing parts of the PDE weak form corresponding to each solution
         component.
 
+        Signature for the function to be returned:
+        ```
+        :arg index: the subinterval index
+        :type index: :class:`int`
+        :arg solutions: map from fields to tuples of current and previous solutions
+        :type solutions: :class:`dict` with :class:`str` keys and :class:`tuple` values
+        :return: map from fields to the corresponding forms
+        :rtype: :class:`dict` with :class:`str` keys and :class:`ufl.form.Form` values
+        ```
+
         :returns: the function for obtaining the form
+        :rtype: see docstring above
         """
         if self._get_form is None:
             raise NotImplementedError("'get_form' needs implementing.")
@@ -279,7 +290,20 @@ class MeshSeq:
         Get the function mapping a subinterval index and an initial condition dictionary
         to a dictionary of solutions for the corresponding solver step.
 
+        Signature for the function to be returned:
+        ```
+        :arg index: the subinterval index
+        :type index: :class:`int`
+        :arg ic: map from fields to the corresponding initial condition components
+        :type ic: :class:`dict` with :class:`str` keys and
+            :class:`firedrake.function.Function` values
+        :return: map from fields to the corresponding solutions
+        :rtype: :class:`dict` with :class:`str` keys and
+            :class:`firedrake.function.Function` values
+        ```
+
         :returns: the function for obtaining the solver
+        :rtype: see docstring above
         """
         if self._get_solver is None:
             raise NotImplementedError("'get_solver' needs implementing.")
@@ -289,6 +313,15 @@ class MeshSeq:
         """
         Get the function mapping a subinterval index to a set of Dirichlet boundary
         conditions.
+
+        Signature for the function to be returned:
+        ```
+        :arg index: the subinterval index
+        :type index: :class:`int`
+        :return: boundary conditions
+        :rtype: :class:`~.DirichletBC` or :class:`list` thereof
+        :rtype: see docstring above
+        ```
 
         :returns: the function for obtaining the boundary conditions
         """

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -12,13 +12,10 @@ from .interpolation import project
 from .log import pyrint, debug, warning, info, logger, DEBUG
 from .options import AdaptParameters
 from animate.quality import QualityMeasure
-from .time_partition import TimePartition
 from .utility import AttrDict, Mesh
 from collections import OrderedDict
-from collections.abc import Callable, Iterable
-import matplotlib
+from collections.abc import Iterable
 import numpy as np
-from typing import Tuple
 
 
 __all__ = ["MeshSeq"]
@@ -31,24 +28,22 @@ class MeshSeq:
     """
 
     @PETSc.Log.EventDecorator()
-    def __init__(self, time_partition: TimePartition, initial_meshes: list, **kwargs):
+    def __init__(self, time_partition, initial_meshes, **kwargs):
         r"""
-        :arg time_partition: the :class:`~.TimePartition` which partitions the temporal
-            domain
-        :arg initial_meshes: list of meshes corresponding to the subintervals of the
-            :class:`~.TimePartition`, or a single mesh to use for all subintervals
-        :kwarg get_function_spaces: a function, whose only argument is a
-            :class:`~.MeshSeq`, which constructs prognostic
-            :class:`firedrake.functionspaceimpl.FunctionSpace`\s for each subinterval
-        :kwarg get_initial_condition: a function, whose only argument is a
-            :class:`~.MeshSeq`, which specifies initial conditions on the first mesh
-        :kwarg get_form: a function, whose only argument is a :class:`~.MeshSeq`, which
-            returns a function that generates the PDE weak form
-        :kwarg get_solver: a function, whose only argument is a :class:`~.MeshSeq`,
-            which returns a function that integrates initial data over a subinterval
-        :kwarg get_bcs: a function, whose only argument is a :class:`~.MeshSeq`, which
-            returns a function that determines any Dirichlet boundary conditions
-        :kwarg parameters: :class:`~.AdaptParameters` instance
+        :arg time_partition: a partition of the temporal domain
+        :type time_partition: :class:`~.TimePartition`
+        :arg initial_meshes: a list of meshes corresponding to the subinterval of the
+            time partition, or a single mesh to use for all subintervals
+        :type initial_meshes: :class:`list` or :class:`~.MeshGeometry`
+        :kwarg get_function_spaces: a function as described in
+            :meth:`~.MeshSeq.get_function_spaces`
+        :kwarg get_initial_condition: a function as described in
+            :meth:`~.MeshSeq.get_initial_condition`
+        :kwarg get_form: a function as described in :meth:`~.MeshSeq.get_form`
+        :kwarg get_solver: a function as described in :meth:`~.MeshSeq.get_solver`
+        :kwarg get_bcs: a function as described in :meth:`~.MeshSeq.get_bcs`
+        :kwarg parameters: parameters to apply to the mesh adaptation process
+        :type parameters: :class:`~.AdaptParameters`
         """
         self.time_partition = time_partition
         self.fields = time_partition.fields
@@ -74,11 +69,11 @@ class MeshSeq:
             self.params = AdaptParameters()
         self.sections = [{} for mesh in self]
 
-    def __str__(self) -> str:
+    def __str__(self):
         return f"{[str(mesh) for mesh in self.meshes]}"
 
-    def __repr__(self) -> str:
-        name = self.__class__.__name__
+    def __repr__(self):
+        name = type(self).__name__
         if len(self) == 1:
             return f"{name}([{repr(self.meshes[0])}])"
         elif len(self) == 2:
@@ -86,43 +81,89 @@ class MeshSeq:
         else:
             return f"{name}([{repr(self.meshes[0])}, ..., {repr(self.meshes[-1])}])"
 
-    def debug(self, msg: str):
-        debug(f"{self.__class__.__name__}: {msg}")
+    def debug(self, msg):
+        """
+        Print a ``debug`` message.
 
-    def warning(self, msg: str):
-        warning(f"{self.__class__.__name__}: {msg}")
+        :arg msg: the message to print
+        :type msg: :class:`str`
+        """
+        debug(f"{type(self).__name__}: {msg}")
 
-    def info(self, msg: str):
-        info(f"{self.__class__.__name__}: {msg}")
+    def warning(self, msg):
+        """
+        Print a ``warning`` message.
 
-    def __len__(self) -> int:
+        :arg msg: the message to print
+        :type msg: :class:`str`
+        """
+        warning(f"{type(self).__name__}: {msg}")
+
+    def info(self, msg):
+        """
+        Print an ``info`` level message.
+
+        :arg msg: the message to print
+        :type msg: :class:`str`
+        """
+        info(f"{type(self).__name__}: {msg}")
+
+    def __len__(self):
         return len(self.meshes)
 
-    def __getitem__(self, i: int) -> firedrake.MeshGeometry:
-        return self.meshes[i]
+    def __getitem__(self, subinterval):
+        """
+        :arg subinterval: a subinterval index
+        :type subinterval: :class:`int`
+        :returns: the corresponding mesh
+        :rtype: :class:`firedrake.MeshGeometry`
+        """
+        return self.meshes[subinterval]
 
-    def __setitem__(
-        self, i: int, mesh: firedrake.MeshGeometry
-    ) -> firedrake.MeshGeometry:
-        self.meshes[i] = mesh
+    def __setitem__(self, subinterval, mesh):
+        """
+        :arg subinterval: a subinterval index
+        :type subinterval: :class:`int`
+        :arg mesh: the mesh to use for that subinterval
+        :type subinterval: :class:`firedrake.MeshGeometry`
+        """
+        self.meshes[subinterval] = mesh
 
-    def count_elements(self) -> list:
+    def count_elements(self):
+        r"""
+        Count the number of elements in each mesh in the sequence.
+
+        :returns: list of element counts
+        :rtype: :class:`list` of :class:`int`\s
+        """
         return [mesh.num_cells() for mesh in self]  # TODO: make parallel safe
 
-    def count_vertices(self) -> list:
+    def count_vertices(self):
+        r"""
+        Count the number of vertices in each mesh in the sequence.
+
+        :returns: list of vertex counts
+        :rtype: :class:`list` of :class:`int`\s
+        """
         return [mesh.num_vertices() for mesh in self]  # TODO: make parallel safe
 
-    def reset_counts(self):
+    def _reset_counts(self):
+        """
+        Reset the lists of element and vertex counts.
+        """
         self.element_counts = [self.count_elements()]
         self.vertex_counts = [self.count_vertices()]
 
     def set_meshes(self, meshes):
-        """
-        Update the meshes associated with the :class:`~.MeshSeq`, as well as the
-        associated attributes.
+        r"""
+        Set all meshes in the sequence and deduce various properties.
 
-        :arg meshes: mesh or list of meshes to use in the sequence
+        :arg meshes: list of meshes to use in the sequence, or a single mesh to use for
+            all subintervals
+        :type meshes: :class:`list` of :class:`firedrake.MeshGeometry`\s or
+            :class:`firedrake.MeshGeometry`
         """
+        # TODO: Refactor to use the set method
         if not isinstance(meshes, Iterable):
             meshes = [Mesh(meshes) for subinterval in self.subintervals]
         self.meshes = meshes
@@ -130,7 +171,7 @@ class MeshSeq:
         if dim.min() != dim.max():
             raise ValueError("Meshes must all have the same topological dimension.")
         self.dim = dim.min()
-        self.reset_counts()
+        self._reset_counts()
         if logger.level == DEBUG:
             for i, mesh in enumerate(meshes):
                 nc = mesh.num_cells()
@@ -143,17 +184,19 @@ class MeshSeq:
                 )
             debug(100 * "-")
 
-    def plot(
-        self, **kwargs
-    ) -> Tuple[matplotlib.figure.Figure, matplotlib.axes._axes.Axes]:
+    def plot(self, fig, axes, **kwargs):
         """
         Plot the meshes comprising a 2D :class:`~.MeshSeq`.
 
-        :kwarg fig: matplotlib figure
-        :kwarg axes: matplotlib axes
-        :kwargs: parameters to pass to :func:`firedrake.pyplot.triplot`
-            function
-        :return: matplotlib figure and axes for the plots
+        :kwarg fig: matplotlib figure to use
+        :type fig: :class:`matplotlib.figure.Figure`
+        :kwarg axes: matplotlib axes to use
+        :type axes: :class:`matplotlib.axes._axes.Axes`
+        :returns: matplotlib figure and axes for the plots
+        :rtype1: :class:`matplotlib.figure.Figure`
+        :rtype2: :class:`matplotlib.axes._axes.Axes`
+
+        All keyword arguments are passed to :func:`firedrake.pyplot.triplot`.
         """
         from matplotlib.pyplot import subplots
 
@@ -161,8 +204,6 @@ class MeshSeq:
             raise ValueError("MeshSeq plotting only supported in 2D")
 
         # Process kwargs
-        fig = kwargs.pop("fig", None)
-        axes = kwargs.pop("axes", None)
         interior_kw = {"edgecolor": "k"}
         interior_kw.update(kwargs.pop("interior_kw", {}))
         boundary_kw = {"edgecolor": "k"}
@@ -191,12 +232,30 @@ class MeshSeq:
             axes = axes[0]
         return fig, axes
 
-    def get_function_spaces(self, mesh: firedrake.MeshGeometry) -> Callable:
+    def get_function_spaces(self, mesh):
+        """
+        Construct the function spaces corresponding to each field, for a given mesh.
+
+        :arg mesh: the mesh to base the function spaces on
+        :type mesh: :class:`firedrake.mesh.MeshGeometry`
+        :returns: a dictionary whose keys are field names and whose values are the
+            corresponding function spaces
+        :rtype: :class:`dict` with :class:`str` keys and
+            :class:`firedrake.functionspaceimpl.FunctionSpace` values
+        """
         if self._get_function_spaces is None:
             raise NotImplementedError("'get_function_spaces' needs implementing.")
         return self._get_function_spaces(mesh)
 
-    def get_initial_condition(self) -> dict:
+    def get_initial_condition(self):
+        r"""
+        Get the initial conditions applied on the first mesh in the sequence.
+
+        :returns: the dictionary, whose keys are field names and whose values are the
+            corresponding initial conditions applied
+        :rtype: :class:`dict` with :class:`str` keys and
+            :class:`firedrake.function.Function` values
+        """
         if self._get_initial_condition is not None:
             return self._get_initial_condition(self)
         return {
@@ -204,22 +263,48 @@ class MeshSeq:
             for field, fs in self.function_spaces.items()
         }
 
-    def get_form(self) -> Callable:
+    def get_form(self):
+        """
+        Get the function mapping a subinterval index and a solution dictionary to a
+        dictionary containing parts of the PDE weak form corresponding to each solution
+        component.
+
+        :returns: the function for obtaining the form
+        """
         if self._get_form is None:
             raise NotImplementedError("'get_form' needs implementing.")
         return self._get_form(self)
 
-    def get_solver(self) -> Callable:
+    def get_solver(self):
+        """
+        Get the function mapping a subinterval index and an initial condition dictionary
+        to a dictionary of solutions for the corresponding solver step.
+
+        :returns: the function for obtaining the solver
+        """
         if self._get_solver is None:
             raise NotImplementedError("'get_solver' needs implementing.")
         return self._get_solver(self)
 
-    def get_bcs(self) -> Callable:
+    def get_bcs(self):
+        """
+        Get the function mapping a subinterval index to a set of Dirichlet boundary
+        conditions.
+
+        :returns: the function for obtaining the boundary conditions
+        """
         if self._get_bcs is not None:
             return self._get_bcs(self)
 
-    @property
-    def _function_spaces_consistent(self) -> bool:
+    def _function_spaces_consistent(self):
+        """
+        Determine whether the mesh sequence's function spaces are consistent with its
+        meshes.
+
+        :returns: ``True`` if the meshes and function spaces are consistent, otherwise
+            ``False``
+        :rtype: `:class:`bool`
+        """
         consistent = len(self.time_partition) == len(self)
         consistent &= all(len(self) == len(self._fs[field]) for field in self.fields)
         for field in self.fields:
@@ -232,33 +317,46 @@ class MeshSeq:
             )
         return consistent
 
-    def update_function_spaces(self) -> list:
+    def _update_function_spaces(self):
         """
-        Update the function space dictionary associated with the :class:`MeshSeq`.
+        Update the function space dictionary associated with the mesh sequence.
         """
-        if self._fs is None or not self._function_spaces_consistent:
-            self._fs = [self.get_function_spaces(mesh) for mesh in self.meshes]
+        if self._fs is None or not self._function_spaces_consistent():
             self._fs = AttrDict(
                 {
-                    field: [self._fs[i][field] for i in range(len(self))]
+                    field: [self.get_function_spaces(mesh)[field] for mesh in self]
                     for field in self.fields
                 }
             )
         assert (
-            self._function_spaces_consistent
+            self._function_spaces_consistent()
         ), "Meshes and function spaces are inconsistent"
-        return self._fs
 
     @property
     def function_spaces(self):
-        return self.update_function_spaces()
+        """
+        Get the function spaces associated with the mesh sequence.
+
+        :returns: a dictionary whose keys are field names and whose values are the
+            corresponding function spaces
+        :rtype: :class:`~.AttrDict` with :class:`str` keys and
+            :class:`firedrake.functionspaceimpl.FunctionSpace` values
+        """
+        self._update_function_spaces()
+        return self._fs
 
     @property
-    def initial_condition(self) -> AttrDict:
+    def initial_condition(self):
+        """
+        Get the initial conditions associated with the first subinterval.
+
+        :returns: a dictionary whose keys are field names and whose values are the
+            corresponding initial conditions applied on the first subinterval
+        :rtype: :class:`~.AttrDict` with :class:`str` keys and
+            :class:`firedrake.function.Function` values
+        """
         ic = OrderedDict(self.get_initial_condition())
-        assert issubclass(
-            ic.__class__, dict
-        ), "`get_initial_condition` should return a dict"
+        assert isinstance(ic, dict), "`get_initial_condition` should return a dict"
         assert set(self.fields).issubset(
             set(ic.keys())
         ), "missing fields in initial condition"
@@ -268,29 +366,40 @@ class MeshSeq:
         return AttrDict(ic)
 
     @property
-    def form(self) -> Callable:
+    def form(self):
+        """
+        See :meth:`~.MeshSeq.get_form`.
+        """
         return self.get_form()
 
     @property
-    def solver(self) -> Callable:
+    def solver(self):
+        """
+        See :meth:`~.MeshSeq.get_solver`.
+        """
         return self.get_solver()
 
     @property
-    def bcs(self) -> Callable:
+    def bcs(self):
+        """
+        See :meth:`~.MeshSeq.get_bcs`.
+        """
         return self.get_bcs()
 
     @PETSc.Log.EventDecorator()
-    def get_checkpoints(
-        self, solver_kwargs: dict = {}, run_final_subinterval: bool = False
-    ) -> list:
-        """
+    def get_checkpoints(self, solver_kwargs={}, run_final_subinterval=False):
+        r"""
         Solve forward on the sequence of meshes, extracting checkpoints corresponding
         to the starting fields on each subinterval.
 
-        :kwarg solver_kwargs: additional keyword arguments which will be passed to the
-            solver
-        :kwarg run_final_subinterval: toggle whether to solve the PDE on the final
+        :kwarg solver_kwargs: parameters for the forward solver
+        :type solver_kwargs: :class:`dict` with :class:`str` keys and values which may
+            take various types
+        :kwarg run_final_subinterval: if ``True``, the solver is run on the final
             subinterval
+        :type run_final_subinterval: :class:`bool`
+        :returns: checkpoints for each subinterval
+        :rtype: :class:`list` of :class:`firedrake.function.Function`\s
         """
         N = len(self)
 
@@ -333,13 +442,17 @@ class MeshSeq:
         return checkpoints
 
     @PETSc.Log.EventDecorator()
-    def get_solve_blocks(self, field: str, subinterval: int) -> list:
-        """
+    def get_solve_blocks(self, field, subinterval):
+        r"""
         Get all blocks of the tape corresponding to solve steps for prognostic solution
         field on a given subinterval.
 
         :arg field: name of the prognostic solution field
+        :type field: :class:`str`
         :arg subinterval: subinterval index
+        :type subinterval: :class:`int`
+        :returns: list of solve blocks
+        :rtype: :class:`list` of :class:`pyadjoint.block.Block`\s
         """
         tape = pyadjoint.get_working_tape()
         if tape is None:
@@ -403,13 +516,19 @@ class MeshSeq:
 
     def _output(self, field, subinterval, solve_block):
         """
-        For a given solve block and solution field, get the block's outputs which
-        corresponds to the solution from the current timestep.
+        For a given solve block and solution field, get the block's outputs corresponding
+        to the solution from the current timestep.
 
         :arg field: field of interest
+        :type field: :class:`str`
         :arg subinterval: subinterval index
-        :arg solve_block: taped :class:`firedrake.adjoint.blocks.GenericSolveBlock`
+        :type subinterval: :class:`int`
+        :arg solve_block: taped solve block
+        :type solve_block: :class:`firedrake.adjoint.blocks.GenericSolveBlock`
+        :returns: the output
+        :rtype: :class:`firedrake.function.Function`
         """
+        # TODO: Inconsistent return value - can be None
         fs = self.function_spaces[field][subinterval]
 
         # Loop through the solve block's outputs
@@ -450,9 +569,15 @@ class MeshSeq:
         corresponds to the solution from the previous timestep.
 
         :arg field: field of interest
+        :type field: :class:`str`
         :arg subinterval: subinterval index
-        :arg solve_block: taped :class:`firedrake.adjoint.blocks.GenericSolveBlock`
+        :type subinterval: :class:`int`
+        :arg solve_block: taped solve block
+        :type solve_block: :class:`firedrake.adjoint.blocks.GenericSolveBlock`
+        :returns: the dependency
+        :rtype: :class:`firedrake.function.Function`
         """
+        # TODO: Inconsistent return value - can be None
         if self.field_types[field] == "steady":
             return
         fs = self.function_spaces[field][subinterval]
@@ -490,38 +615,34 @@ class MeshSeq:
             )
 
     def _create_solutions(self):
+        """
+        Create the :class:`~.FunctionData` instance for holding solution data.
+        """
         self._solutions = ForwardSolutionData(self.time_partition, self.function_spaces)
 
     @property
     def solutions(self):
         """
-        Arrays holding exported solution fields and their lagged counterparts.
+        :returns: the solution data object
+        :rtype: :class:`~.FunctionData`
         """
         if not hasattr(self, "_solutions"):
             self._create_solutions()
         return self._solutions
 
     @PETSc.Log.EventDecorator()
-    def solve_forward(self, solver_kwargs: dict = {}) -> AttrDict:
-        """
+    def solve_forward(self, solver_kwargs={}):
+        r"""
         Solve a forward problem on a sequence of subintervals.
 
-        A dictionary of solution fields is computed, the contents of which give values
-        at all exported timesteps, indexed first by the field label and then by type.
-        The contents of these nested dictionaries are nested lists which are indexed
-        first by subinterval and then by export. For a given exported timestep, the
-        field types are:
+        A dictionary of solution fields is computed - see :class:`~.ForwardSolutionData`
+        for more details.
 
-        * ``'forward'``: the forward solution after taking the timestep;
-        * ``'forward_old'``: the forward solution before taking the timestep (provided
-          the problem is not steady-state).
-
-        :kwarg solver_kwargs: a dictionary providing parameters to the solver. Any
-            keyword arguments for the QoI should be included as a subdict with label
-            'qoi_kwargs'
-
-        :return solution: an :class:`~.AttrDict` containing solution fields and their
-            lagged versions. This can also be accessed as :meth:`solutions`.
+        :kwarg solver_kwargs: parameters for the forward solver
+        :type solver_kwargs: :class:`dict` whose keys are :class:`str`\s and whose values
+            may take various types
+        :returns: the solution data of the forward solves
+        :rtype: :class:`~.ForwardSolutionData`
         """
         num_subintervals = len(self)
         P = self.time_partition
@@ -596,12 +717,13 @@ class MeshSeq:
         return self.solutions
 
     def check_element_count_convergence(self):
-        """
+        r"""
         Check for convergence of the fixed point iteration due to the relative
         difference in element count being smaller than the specified tolerance.
 
-        :return: Boolean array with ``True`` in the appropriate entry if convergence is
-            detected on a subinterval.
+        :return: an array, whose entries are ``True`` if convergence is detected on the
+            corresponding subinterval
+        :rtype: :class:`list` of :class:`bool`\s
         """
         if self.params.drop_out_converged:
             converged = self.converged
@@ -639,27 +761,26 @@ class MeshSeq:
 
     @PETSc.Log.EventDecorator()
     def fixed_point_iteration(
-        self,
-        adaptor: Callable,
-        solver_kwargs: dict = {},
-        adaptor_kwargs: dict = {},
-        **kwargs,
+        self, adaptor, update_params=None, solver_kwargs={}, adaptor_kwargs={}
     ):
         r"""
-        Apply goal-oriented mesh adaptation using a fixed point iteration loop.
+        Apply mesh adaptation using a fixed point iteration loop approach.
 
-        :arg adaptor: function for adapting the mesh sequence. Its arguments are the
-            :class:`~.MeshSeq` instance and the dictionary of solution
-            :class:`firedrake.function.Function`\s. It should return ``True`` if the
+        :arg adaptor: function for adapting the mesh sequence. Its arguments are the mesh
+            sequence and the solution data object. It should return ``True`` if the
             convergence criteria checks are to be skipped for this iteration. Otherwise,
             it should return ``False``.
         :kwarg update_params: function for updating :attr:`~.MeshSeq.params` at each
             iteration. Its arguments are the parameter class and the fixed point
             iteration
-        :kwarg solver_kwargs: a dictionary providing parameters to the solver
-        :kwarg adaptor_kwargs: a dictionary providing parameters to the adaptor
+        :kwarg solver_kwargs: parameters to pass to the solver
+        :type solver_kwargs: :class:`dict`
+        :kwarg adaptor_kwargs: parameters to pass to the adaptor
+        :type adaptor_kwargs: :class:`dict`
+        :returns: solution data object
+        :rtype: :class:`~.ForwardSolutionData`
         """
-        update_params = kwargs.get("update_params")
+        # TODO: adaptor no longer needs solution data to be passed explicitly
         self.element_counts = [self.count_elements()]
         self.vertex_counts = [self.count_vertices()]
         self.converged[:] = False

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -13,7 +13,6 @@ from .log import pyrint, debug, warning, info, logger, DEBUG
 from .options import AdaptParameters
 from animate.quality import QualityMeasure
 from .utility import AttrDict, Mesh
-from collections import OrderedDict
 from collections.abc import Iterable
 import numpy as np
 
@@ -355,15 +354,19 @@ class MeshSeq:
         :rtype: :class:`~.AttrDict` with :class:`str` keys and
             :class:`firedrake.function.Function` values
         """
-        ic = OrderedDict(self.get_initial_condition())
-        assert isinstance(ic, dict), "`get_initial_condition` should return a dict"
-        assert set(self.fields).issubset(
-            set(ic.keys())
+        initial_condition_map = self.get_initial_condition()
+        assert isinstance(
+            initial_condition_map, dict
+        ), "`get_initial_condition` should return a dict"
+        mesh_seq_fields = set(self.fields)
+        initial_condition_fields = set(initial_condition_map.keys())
+        assert mesh_seq_fields.issubset(
+            initial_condition_fields
         ), "missing fields in initial condition"
-        assert set(ic.keys()).issubset(
-            set(self.fields)
+        assert initial_condition_fields.issubset(
+            mesh_seq_fields
         ), "more initial conditions than fields"
-        return AttrDict(ic)
+        return AttrDict(initial_condition_map)
 
     @property
     def form(self):

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -184,7 +184,7 @@ class MeshSeq:
                 )
             debug(100 * "-")
 
-    def plot(self, fig, axes, **kwargs):
+    def plot(self, fig=None, axes=None, **kwargs):
         """
         Plot the meshes comprising a 2D :class:`~.MeshSeq`.
 

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -136,7 +136,7 @@ class MeshSeq:
         :returns: list of element counts
         :rtype: :class:`list` of :class:`int`\s
         """
-        return [mesh.num_cells() for mesh in self]  # TODO: make parallel safe
+        return [mesh.num_cells() for mesh in self]  # TODO #123: make parallel safe
 
     def count_vertices(self):
         r"""
@@ -145,7 +145,7 @@ class MeshSeq:
         :returns: list of vertex counts
         :rtype: :class:`list` of :class:`int`\s
         """
-        return [mesh.num_vertices() for mesh in self]  # TODO: make parallel safe
+        return [mesh.num_vertices() for mesh in self]  # TODO #123: make parallel safe
 
     def _reset_counts(self):
         """
@@ -163,7 +163,7 @@ class MeshSeq:
         :type meshes: :class:`list` of :class:`firedrake.MeshGeometry`\s or
             :class:`firedrake.MeshGeometry`
         """
-        # TODO: Refactor to use the set method
+        # TODO #122: Refactor to use the set method
         if not isinstance(meshes, Iterable):
             meshes = [Mesh(meshes) for subinterval in self.subintervals]
         self.meshes = meshes
@@ -528,7 +528,7 @@ class MeshSeq:
         :returns: the output
         :rtype: :class:`firedrake.function.Function`
         """
-        # TODO: Inconsistent return value - can be None
+        # TODO #93: Inconsistent return value - can be None
         fs = self.function_spaces[field][subinterval]
 
         # Loop through the solve block's outputs
@@ -577,7 +577,7 @@ class MeshSeq:
         :returns: the dependency
         :rtype: :class:`firedrake.function.Function`
         """
-        # TODO: Inconsistent return value - can be None
+        # TODO #93: Inconsistent return value - can be None
         if self.field_types[field] == "steady":
             return
         fs = self.function_spaces[field][subinterval]
@@ -780,7 +780,7 @@ class MeshSeq:
         :returns: solution data object
         :rtype: :class:`~.ForwardSolutionData`
         """
-        # TODO: adaptor no longer needs solution data to be passed explicitly
+        # TODO #124: adaptor no longer needs solution data to be passed explicitly
         self.element_counts = [self.count_elements()]
         self.vertex_counts = [self.count_vertices()]
         self.converged[:] = False

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -774,9 +774,11 @@ class MeshSeq:
             iteration. Its arguments are the parameter class and the fixed point
             iteration
         :kwarg solver_kwargs: parameters to pass to the solver
-        :type solver_kwargs: :class:`dict`
+        :type solver_kwargs: :class:`dict` with :class:`str` keys and values which may
+            take various types
         :kwarg adaptor_kwargs: parameters to pass to the adaptor
-        :type adaptor_kwargs: :class:`dict`
+        :type adaptor_kwargs: :class:`dict` with :class:`str` keys and values which may
+            take various types
         :returns: solution data object
         :rtype: :class:`~.ForwardSolutionData`
         """

--- a/goalie/options.py
+++ b/goalie/options.py
@@ -16,9 +16,11 @@ class AdaptParameters(AttrDict):
     loops.
     """
 
-    def __init__(self, parameters: dict = {}):
+    def __init__(self, parameters={}):
         """
-        :arg parameters: dictionary of parameters to set
+        :arg parameters: parameters to set
+        :type parameters: :class:`dict` with :class:`str` keys and values which may take
+            various types
         """
         self["miniter"] = 3  # Minimum iteration count
         self["maxiter"] = 35  # Maximum iteration count
@@ -42,6 +44,14 @@ class AdaptParameters(AttrDict):
         self._check_type("drop_out_converged", bool)
 
     def _check_type(self, key, expected):
+        """
+        Check that a given parameter is of the expected type.
+
+        :arg key: the parameter label
+        :type key: :class:`str`
+        :arg expected: the expected type
+        :type expected: :class:`type`
+        """
         if not isinstance(self[key], expected):
             if isinstance(expected, tuple):
                 name = "' or '".join([e.__name__ for e in expected])
@@ -53,18 +63,26 @@ class AdaptParameters(AttrDict):
             )
 
     def _check_value(self, key, possibilities):
+        """
+        Check that a given parameter takes one of the possible values.
+
+        :arg key: the parameter label
+        :type key: :class:`str`
+        :arg possibilities: all possible values for the parameter
+        :type possibilities: :class:`list`
+        """
         value = self[key]
         if value not in possibilities:
             raise ValueError(
                 f"Unsupported value '{value}' for '{key}'. Choose from {possibilities}."
             )
 
-    def __str__(self) -> str:
+    def __str__(self):
         return str({key: value for key, value in self.items()})
 
-    def __repr__(self) -> str:
+    def __repr__(self):
         d = ", ".join([f"{key}={value}" for key, value in self.items()])
-        return f"{self.__class__.__name__}({d})"
+        return f"{type(self).__name__}({d})"
 
 
 class MetricParameters(AdaptParameters):
@@ -73,9 +91,11 @@ class MetricParameters(AdaptParameters):
     metric-based adaptive mesh fixed point iteration loops.
     """
 
-    def __init__(self, parameters: dict = {}):
+    def __init__(self, parameters={}):
         """
-        :arg parameters: dictionary of parameters to set
+        :arg parameters: parameters to set
+        :type parameters: :class:`dict` with :class:`str` keys and values which may take
+            various types
         """
         self["num_ramp_iterations"] = 3  # Number of iterations to ramp over
         self["verbosity"] = -1  # -1 = silent, 10 = maximum
@@ -124,7 +144,8 @@ class MetricParameters(AdaptParameters):
         """
         Set parameters appropriate to a given :class:`RiemannianMetric`.
 
-        :arg metric: the :class:`RiemannianMetric` to apply parameters to
+        :arg metric: the metric to apply parameters to
+        :type metric: :class:`animate.metric.RiemannianMetric`
         """
         if not isinstance(metric, RiemannianMetric):
             raise TypeError(
@@ -160,7 +181,12 @@ class GoalOrientedParameters(AdaptParameters):
     loops.
     """
 
-    def __init__(self, parameters: dict = {}):
+    def __init__(self, parameters={}):
+        """
+        :arg parameters: parameters to set
+        :type parameters: :class:`dict` with :class:`str` keys and values which may take
+            various types
+        """
         self["qoi_rtol"] = 0.001  # Relative tolerance for QoI
         self["estimator_rtol"] = 0.001  # Relative tolerance for estimator
         self["convergence_criteria"] = "any"  # Mode for convergence checking

--- a/goalie/point_seq.py
+++ b/goalie/point_seq.py
@@ -43,4 +43,4 @@ class PointSeq(MeshSeq):
         self.meshes = [mesh for _ in self.subintervals]
         self.dim = mesh.topological_dimension()
         assert self.dim == 0
-        self.reset_counts()
+        self._reset_counts()

--- a/goalie/time_partition.py
+++ b/goalie/time_partition.py
@@ -4,7 +4,6 @@ Partitioning for the temporal domain.
 from .log import debug
 from collections.abc import Iterable
 import numpy as np
-from typing import List, Optional, Union
 
 
 __all__ = ["TimePartition", "TimeInterval", "TimeInstant"]
@@ -20,27 +19,37 @@ class TimePartition:
 
     def __init__(
         self,
-        end_time: float,
-        num_subintervals: int,
-        timesteps: Union[List[float], float],
-        fields: Union[List[str], str],
-        num_timesteps_per_export: int = 1,
-        start_time: float = 0.0,
-        subintervals: Optional[List[float]] = None,
-        field_types: Optional[Union[List[str], str]] = None,
+        end_time,
+        num_subintervals,
+        timesteps,
+        fields,
+        num_timesteps_per_export=1,
+        start_time=0.0,
+        subintervals=None,
+        field_types=None,
     ):
-        """
+        r"""
         :arg end_time: end time of the interval of interest
+        :type end_time: :class:`float` or :class:`int`
         :arg num_subintervals: number of subintervals in the partition
-        :arg timesteps: (list of values for the) timestep used on each subinterval
-        :arg fields: (list of) field names
-        :kwarg num_timesteps_per_export: (list of) number of timesteps per export
+        :type num_subintervals: :class:`int`
+        :arg timesteps: a list timesteps to be used on each subinterval, or a single
+            timestep to use for all subintervals
+        :type timesteps: :class:`list` of :class:`float`\s or :class:`float`
+        :arg fields: the list of field names to consider
+        :type fields: :class:`list` of :class:`str`\s or :class:`str`
+        :kwarg num_timesteps_per_export: a list of numbers of timesteps per export for
+            each subinterval, or a single number to use for all subintervals
+        :type num_timesteps_per_export: :class:`list` of :class`int`\s or :class:`int`
         :kwarg start_time: start time of the interval of interest
-        :kwarg subinterals: user-provided sequence of subintervals, which need not be of
-            uniform length
-        :kwarg field_types: (list of) strings indicating whether each field is
+        :type start_time: :class:`float` or :class:`int`
+        :kwarg subinterals: sequence of subintervals (which need not be of uniform
+            length), or ``None`` to use uniform subintervals (the default)
+        :type subintervals: :class:`list` of :class:`tuple`\s
+        :kwarg field_types: a list of strings indicating whether each field is
             'unsteady' or 'steady', i.e., does the corresponding equation involve time
             derivatives or not?
+        :type field_types: :class:`list` of :class:`str`\s or :class:`str`
         """
         debug(100 * "-")
         if isinstance(fields, str):
@@ -120,9 +129,11 @@ class TimePartition:
         debug("field_types")
         debug(100 * "-")
 
-    def debug(self, attr: str):
+    def debug(self, attr):
         """
         Print attribute 'msg' for debugging purposes.
+
+        :arg attr: the attribute to display debugging information for
         """
         try:
             val = self.__getattribute__(attr)
@@ -133,10 +144,10 @@ class TimePartition:
         label = " ".join(attr.split("_"))
         debug(f"TimePartition: {label:25s} {val}")
 
-    def __str__(self) -> str:
+    def __str__(self):
         return f"{self.subintervals}"
 
-    def __repr__(self) -> str:
+    def __repr__(self):
         timesteps = ", ".join([str(dt) for dt in self.timesteps])
         fields = ", ".join([f"'{field}'" for field in self.fields])
         return (
@@ -147,14 +158,17 @@ class TimePartition:
             f"fields=[{fields}])"
         )
 
-    def __len__(self) -> int:
+    def __len__(self):
         return self.num_subintervals
 
-    def __getitem__(self, sl: Union[int, slice]) -> dict:
+    def __getitem__(self, index_or_slice):
         """
-        :arg sl: index or slice
-        :return: subinterval bounds and timestep associated with that index
+        :arg index_or_slice: an index or slice to generate a sub-time partition for
+        :type index_or_slice: :class:`int` or :class:`slice`
+        :returns: a time partition for the given index or slice
+        :rtype: :class:`~.TimePartition`
         """
+        sl = index_or_slice
         if not isinstance(sl, slice):
             sl = slice(sl, sl + 1, 1)
         step = sl.step or 1
@@ -175,6 +189,10 @@ class TimePartition:
 
     @property
     def num_timesteps(self):
+        """
+        :returns the total number of timesteps
+        :rtype: :class:`int`
+        """
         return sum(self.num_timesteps_per_subinterval)
 
     def _check_subintervals(self):
@@ -274,7 +292,7 @@ class TimePartition:
 
 class TimeInterval(TimePartition):
     """
-    A trivial :class:`~.TimePartition`.
+    A trivial :class:`~.TimePartition` with a single subinterval.
     """
 
     def __init__(self, *args, **kwargs):
@@ -288,7 +306,7 @@ class TimeInterval(TimePartition):
         fields = args[2]
         super().__init__(end_time, 1, timestep, fields, **kwargs)
 
-    def __repr__(self) -> str:
+    def __repr__(self):
         return (
             f"TimeInterval("
             f"end_time={self.end_time}, "
@@ -297,7 +315,11 @@ class TimeInterval(TimePartition):
         )
 
     @property
-    def timestep(self) -> float:
+    def timestep(self):
+        """
+        :returns: the timestep used on the single interval
+        :rtype: :class:`float`
+        """
         return self.timesteps[0]
 
 
@@ -305,11 +327,10 @@ class TimeInstant(TimeInterval):
     """
     A :class:`~.TimePartition` for steady-state problems.
 
-    Under the hood this means dividing :math:`[0,1)` into
-    a single timestep.
+    Under the hood this means dividing :math:`[0,1)` into a single timestep.
     """
 
-    def __init__(self, fields: Union[List[str], str], **kwargs):
+    def __init__(self, fields, **kwargs):
         if "end_time" in kwargs:
             if "time" in kwargs:
                 raise ValueError("Both 'time' and 'end_time' are set.")
@@ -319,8 +340,8 @@ class TimeInstant(TimeInterval):
         timestep = time
         super().__init__(time, timestep, fields, **kwargs)
 
-    def __str__(self) -> str:
+    def __str__(self):
         return f"({self.end_time})"
 
-    def __repr__(self) -> str:
+    def __repr__(self):
         return f"TimeInstant(" f"time={self.end_time}, " f"fields={self.fields})"

--- a/goalie/utility.py
+++ b/goalie/utility.py
@@ -263,19 +263,20 @@ class AttrDict(dict):
         self.__dict__ = self
 
 
-def effectivity_index(error_indicator: firedrake.Function, Je: float) -> float:
+def effectivity_index(error_indicator, Je):
     r"""
-    Overestimation factor of some error estimator
-    for the QoI error.
+    Compute the overestimation factor of some error estimator for the QoI error.
 
-    Note that this is only typically used for simple
-    steady-state problems with analytical solutions.
+    Note that this is only typically used for simple steady-state problems with
+    analytical solutions.
 
-    :arg error_indicator: a :math:`\mathbb P0`
-        :class:`firedrake.function.Function` which
-        localises contributions to an error estimator
-        to individual elements
-    :arg Je: error in quantity of interest
+    :arg error_indicator: a :math:`\mathbb P0` error indicator which localises
+        contributions to an error estimator to individual elements
+    :type error_indicator: :class:`firedrake.function.Function`
+    :arg Je: the error in the quantity of interest
+    :type Je: :class:`float`
+    :returns: the effectivity index
+    :rtype: :class:`float`
     """
     if not isinstance(error_indicator, firedrake.Function):
         raise ValueError("Error indicator must return a Function.")
@@ -286,9 +287,7 @@ def effectivity_index(error_indicator: firedrake.Function, Je: float) -> float:
     return np.abs(eta / Je)
 
 
-def create_directory(
-    path: str, comm: mpi4py.MPI.Intracomm = firedrake.COMM_WORLD
-) -> str:
+def create_directory(path, comm=firedrake.COMM_WORLD):
     """
     Create a directory on disk.
 
@@ -296,7 +295,11 @@ def create_directory(
     <https://thetisproject.org>`__.
 
     :arg path: path to the directory
+    :type path: :class:`str`
     :kwarg comm: MPI communicator
+    :type comm: :class:`mpi4py.MPI.Intracomm`
+    :returns: the path in absolute form
+    :rtype path: :class:`str`
     """
     if comm.rank == 0:
         if not os.path.exists(path):

--- a/goalie/utility.py
+++ b/goalie/utility.py
@@ -154,7 +154,7 @@ def norm(v, norm_type="L2", condition=None, boundary=False):
     r"""
     Overload :func:`firedrake.norms.norm` to allow for :math:`\ell^p` norms.
 
-    Currently supported options:
+    Currently supported ``norm_type`` options:
     * ``'l1'``
     * ``'l2'``
     * ``'linf'``
@@ -226,7 +226,7 @@ def errornorm(u, uh, norm_type="L2", boundary=False, **kwargs):
     r"""
     Overload :func:`firedrake.norms.errornorm` to allow for :math:`\ell^p` norms.
 
-    Currently supported options:
+    Currently supported ``norm_type`` options:
     * ``'l1'``
     * ``'l2'``
     * ``'linf'``


### PR DESCRIPTION
Closes #121, Closes #127.

It is better practice to mention the types of arguments and return values in the docstring, rather than using type hints. Doing so ensures that this information ends up in the docs. (The `metric` module is not addressed because it is covered in #56.)

This PR also:
* makes a few methods and attributes private
* rewords docstrings for readability
* uses `type(self)` rather than `self.__class__`
* uses `solver_kwargs` rather than `adj_kwargs`
* gives `TODO`s issue numbers

Would you mind reviewing this @acse-ej321? Apologies that it is somewhat long and boring.