### PR TITLE
Reinitialise output dictionaries before solving

### DIFF
--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -219,7 +219,7 @@ class AdjointMeshSeq(MeshSeq):
         solver = self.solver
         qoi_kwargs = solver_kwargs.get("qoi_kwargs", {})
 
-        # Reinitialise the solutions dictionary
+        # Reinitialise the solution data object
         self._create_solutions()
 
         # Solve forward to get checkpoints and evaluate QoI

--- a/goalie/adjoint.py
+++ b/goalie/adjoint.py
@@ -219,6 +219,9 @@ class AdjointMeshSeq(MeshSeq):
         solver = self.solver
         qoi_kwargs = solver_kwargs.get("qoi_kwargs", {})
 
+        # Reinitialise the solutions dictionary
+        self._create_solutions()
+
         # Solve forward to get checkpoints and evaluate QoI
         checkpoints = self.get_checkpoints(
             solver_kwargs=solver_kwargs,

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -126,7 +126,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
         enriched_mesh_seq = self.get_enriched_mesh_seq(**enrichment_kwargs)
         transfer = self._get_transfer_function(enrichment_kwargs["enrichment_method"])
 
-        # Reinitialise the error indicators dictionary
+        # Reinitialise the error indicator data object
         self._create_indicators()
 
         # Solve the forward and adjoint problems on the MeshSeq and its enriched version

--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -126,6 +126,9 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
         enriched_mesh_seq = self.get_enriched_mesh_seq(**enrichment_kwargs)
         transfer = self._get_transfer_function(enrichment_kwargs["enrichment_method"])
 
+        # Reinitialise the error indicators dictionary
+        self._create_indicators()
+
         # Solve the forward and adjoint problems on the MeshSeq and its enriched version
         self.solve_adjoint(**adj_kwargs)
         enriched_mesh_seq.solve_adjoint(**adj_kwargs)
@@ -282,8 +285,6 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
                 update_params(self.params, self.fp_iteration)
 
             # Indicate errors over all meshes
-            self._create_solutions()
-            self._create_indicators()
             self.indicate_errors(
                 enrichment_kwargs=enrichment_kwargs,
                 adj_kwargs=adj_kwargs,

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -527,6 +527,9 @@ class MeshSeq:
         P = self.time_partition
         solver = self.solver
 
+        # Reinitialise the solutions dictionary
+        self._create_solutions()
+
         # Start annotating
         if pyadjoint.annotate_tape():
             tape = pyadjoint.get_working_tape()
@@ -670,7 +673,6 @@ class MeshSeq:
                 update_params(self.params, self.fp_iteration)
 
             # Solve the forward problem over all meshes
-            self._create_solutions()
             self.solve_forward(solver_kwargs=solver_kwargs)
 
             # Adapt meshes, logging element and vertex counts

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -527,7 +527,7 @@ class MeshSeq:
         P = self.time_partition
         solver = self.solver
 
-        # Reinitialise the solutions dictionary
+        # Reinitialise the solution data object
         self._create_solutions()
 
         # Start annotating


### PR DESCRIPTION
Closes #138.

Reinitialise solution and error indicator dictionaries at the beginning of `solve_forward`, `solve_adjoint` or `indicate_errors`, rather than at the beginning of `fixed_point_iteration`.