### PR TITLE
Parallel-safe counting

### DIFF
--- a/goalie/go_mesh_seq.py
+++ b/goalie/go_mesh_seq.py
@@ -311,8 +311,7 @@ class GoalOrientedMeshSeq(AdjointMeshSeq):
         """
         # TODO #124: adaptor no longer needs solution and indicator data to be passed
         #            explicitly
-        self.element_counts = [self.count_elements()]
-        self.vertex_counts = [self.count_vertices()]
+        self._reset_counts()
         self.qoi_values = []
         self.estimator_values = []
         self.converged[:] = False

--- a/goalie/mesh_seq.py
+++ b/goalie/mesh_seq.py
@@ -16,6 +16,8 @@ from .utility import AttrDict, Mesh
 from collections.abc import Iterable
 import numpy as np
 
+comm = firedrake.COMM_WORLD
+
 
 __all__ = ["MeshSeq"]
 
@@ -135,7 +137,7 @@ class MeshSeq:
         :returns: list of element counts
         :rtype: :class:`list` of :class:`int`\s
         """
-        return [mesh.num_cells() for mesh in self]  # TODO #123: make parallel safe
+        return [comm.allreduce(mesh.coordinates.cell_set.size) for mesh in self]
 
     def count_vertices(self):
         r"""
@@ -144,7 +146,7 @@ class MeshSeq:
         :returns: list of vertex counts
         :rtype: :class:`list` of :class:`int`\s
         """
-        return [mesh.num_vertices() for mesh in self]  # TODO #123: make parallel safe
+        return [comm.allreduce(mesh.coordinates.node_set.size) for mesh in self]
 
     def _reset_counts(self):
         """
@@ -173,13 +175,13 @@ class MeshSeq:
         self._reset_counts()
         if logger.level == DEBUG:
             for i, mesh in enumerate(meshes):
-                nc = mesh.num_cells()
-                nv = mesh.num_vertices()
+                nc = self.element_counts[0][i]
+                nv = self.vertex_counts[0][i]
                 qm = QualityMeasure(mesh)
                 ar = qm("aspect_ratio")
                 mar = ar.vector().gather().max()
                 self.debug(
-                    f"{i}: {nc:7d} cells, {nv:7d} vertices,   max aspect ratio {mar:.2f}"
+                    f"{i}: {nc:7d} cells, {nv:7d} vertices,  max aspect ratio {mar:.2f}"
                 )
             debug(100 * "-")
 
@@ -822,8 +824,7 @@ class MeshSeq:
         :rtype: :class:`~.ForwardSolutionData`
         """
         # TODO #124: adaptor no longer needs solution data to be passed explicitly
-        self.element_counts = [self.count_elements()]
-        self.vertex_counts = [self.count_vertices()]
+        self._reset_counts()
         self.converged[:] = False
         self.check_convergence[:] = True
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,7 +2,7 @@ all: run
 
 run:
 	@echo "Running all tests..."
-	@python3 -m pytest -v --durations=20 .
+	@python3 -m pytest -v -s -n auto --durations=20 .
 	@echo "Done."
 
 clean:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,57 +3,6 @@ Global pytest configuration.
 
 **Disclaimer: some functions copied from firedrake/src/tests/conftest.py
 """
-from subprocess import check_call
-
-
-def parallel(item):
-    """
-    Run a test in parallel.
-
-    **Disclaimer: copied from firedrake/src/tests/conftest.py
-
-    :arg item: the test item to run.
-    """
-    from mpi4py import MPI
-
-    if MPI.COMM_WORLD.size > 1:
-        raise RuntimeError("Parallel test can't be run within parallel environment")
-    marker = item.get_closest_marker("parallel")
-    if marker is None:
-        raise RuntimeError("Parallel test doesn't have parallel marker")
-    nprocs = marker.kwargs.get("nprocs", 3)
-    if nprocs < 2:
-        raise RuntimeError("Need at least two processes to run parallel test")
-
-    # Only spew tracebacks on rank 0.
-    # Run xfailing tests to ensure that errors are reported to calling process.
-    call = [
-        "mpiexec",
-        "-n",
-        "1",
-        "python",
-        "-m",
-        "pytest",
-        "--runxfail",
-        "-s",
-        "-q",
-        "%s::%s" % (item.fspath, item.name),
-    ]
-    call.extend(
-        [
-            ":",
-            "-n",
-            "%d" % (nprocs - 1),
-            "python",
-            "-m",
-            "pytest",
-            "--runxfail",
-            "--tb=no",
-            "-q",
-            "%s::%s" % (item.fspath, item.name),
-        ]
-    )
-    check_call(call)
 
 
 def pytest_configure(config):
@@ -64,50 +13,8 @@ def pytest_configure(config):
     """
     config.addinivalue_line(
         "markers",
-        "parallel(nprocs): mark test to run in parallel on nprocs processors",
-    )
-    config.addinivalue_line(
-        "markers",
         "slow: mark test as slow to run",
     )
-
-
-def pytest_runtest_setup(item):
-    """
-    **Disclaimer: copied from firedrake/src/tests/conftest.py
-    """
-    if item.get_closest_marker("parallel"):
-        from mpi4py import MPI
-
-        if MPI.COMM_WORLD.size > 1:
-            # Turn on source hash checking
-            from firedrake import parameters
-            from functools import partial
-
-            def _reset(check):
-                parameters["pyop2_options"]["check_src_hashes"] = check
-
-            # Reset to current value when test is cleaned up
-            item.addfinalizer(
-                partial(_reset, parameters["pyop2_options"]["check_src_hashes"])
-            )
-
-            parameters["pyop2_options"]["check_src_hashes"] = True
-        else:
-            # Blow away function arg in "master" process, to ensure
-            # this test isn't run on only one process.
-            item.obj = lambda *args, **kwargs: True
-
-
-def pytest_runtest_call(item):
-    """
-    **Disclaimer: copied from firedrake/src/tests/conftest.py
-    """
-    from mpi4py import MPI
-
-    if item.get_closest_marker("parallel") and MPI.COMM_WORLD.size == 1:
-        # Spawn parallel processes to run test
-        parallel(item)
 
 
 def pytest_runtest_teardown(item, nextitem):

--- a/test/test_parallel.py
+++ b/test/test_parallel.py
@@ -1,0 +1,13 @@
+from goalie.mesh_seq import MeshSeq
+from goalie.time_partition import TimeInterval
+from firedrake import *
+import pytest
+
+
+@pytest.mark.parallel(nprocs=2)
+def test_counting_parallel():
+    assert COMM_WORLD.size == 2
+    time_interval = TimeInterval(1.0, [0.5], ["field"])
+    mesh_seq = MeshSeq(time_interval, [UnitSquareMesh(3, 3)])
+    assert mesh_seq.count_elements() == [18]
+    assert mesh_seq.count_vertices() == [16]


### PR DESCRIPTION
Closes #123.

@jwallwork23, I had to remove the part of conftest.py which configures the settings for the parallel-marked tests. I hope that's okay? I couldn't get the test to pass with it. This way it seems to use settings from the firedrake import - like we are doing in animate parallel tests?