### PR TITLE
146 function data steady label

### DIFF
--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -19,8 +19,6 @@ class FunctionData(abc.ABC):
     Abstract base class for classes holding field data.
     """
 
-    _label_dict = {}
-
     def __init__(self, time_partition, function_spaces):
         r"""
         :arg time_partition: the :class:`~.TimePartition` used to discretise the problem

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -29,7 +29,10 @@ class FunctionData(abc.ABC):
         self.time_partition = time_partition
         self.function_spaces = function_spaces
         self._data = None
-        self.labels = self._label_dict["steady"] + self._label_dict["unsteady"]
+        self.labels = [
+            [label for label in self._label_dict[field]]
+            for field in self.time_partition.field_types
+        ][0]
 
     def _create_data(self):
         assert self._label_dict
@@ -79,16 +82,16 @@ class FunctionData(abc.ABC):
         layout: indexed first by subinterval and then by export.
         """
         tp = self.time_partition
-        _labels = []
-        for field_type in tp.field_types:
-            _labels.extend(self._label_dict[field_type])
+        # _labels = []
+        # for field_type in tp.field_types:
+        #     _labels.extend(self._label_dict[field_type])
 
         return AttrDict(
             {
                 label: AttrDict(
                     {field: self._data_by_field[field][label] for field in tp.fields}
                 )
-                for label in _labels
+                for label in self.labels
             }
         )
 
@@ -102,9 +105,9 @@ class FunctionData(abc.ABC):
         data, indexed by export.
         """
         tp = self.time_partition
-        _labels = []
-        for field_type in tp.field_types:
-            _labels.extend(self._label_dict[field_type])
+        # _labels = []
+        # for field_type in tp.field_types:
+        #     _labels.extend(self._label_dict[field_type])
 
         return [
             AttrDict(
@@ -112,7 +115,7 @@ class FunctionData(abc.ABC):
                     field: AttrDict(
                         {
                             label: self._data_by_field[field][label][subinterval]
-                            for label in _labels
+                            for label in self.labels
                         }
                     )
                     for field in tp.fields

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -1,6 +1,7 @@
 r"""
 Nested dictionaries of solution data :class:`~.Function`\s.
 """
+
 import firedrake.function as ffunc
 import firedrake.functionspace as ffs
 from .utility import AttrDict
@@ -80,12 +81,16 @@ class FunctionData(abc.ABC):
         layout: indexed first by subinterval and then by export.
         """
         tp = self.time_partition
+        _labels = []
+        for field_type in tp.field_types:
+            _labels.extend(self._label_dict[field_type])
+
         return AttrDict(
             {
                 label: AttrDict(
                     {field: self._data_by_field[field][label] for field in tp.fields}
                 )
-                for label in self.labels
+                for label in _labels
             }
         )
 
@@ -99,13 +104,17 @@ class FunctionData(abc.ABC):
         data, indexed by export.
         """
         tp = self.time_partition
+        _labels = []
+        for field_type in tp.field_types:
+            _labels.extend(self._label_dict[field_type])
+
         return [
             AttrDict(
                 {
                     field: AttrDict(
                         {
                             label: self._data_by_field[field][label][subinterval]
-                            for label in self.labels
+                            for label in _labels
                         }
                     )
                     for field in tp.fields

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -29,14 +29,9 @@ class FunctionData(abc.ABC):
         self.time_partition = time_partition
         self.function_spaces = function_spaces
         self._data = None
-        self.labels = (
-            [
-                [label for label in self._label_dict[field]]
-                for field in self.time_partition.field_types
-            ][0]
-            if self.time_partition.fields
-            else []
-        )
+        self.labels = self._label_dict[
+            "steady" if time_partition.steady else "unsteady"
+        ]
 
     def _create_data(self):
         assert self._label_dict

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -86,10 +86,6 @@ class FunctionData(abc.ABC):
         layout: indexed first by subinterval and then by export.
         """
         tp = self.time_partition
-        # _labels = []
-        # for field_type in tp.field_types:
-        #     _labels.extend(self._label_dict[field_type])
-
         return AttrDict(
             {
                 label: AttrDict(
@@ -109,10 +105,6 @@ class FunctionData(abc.ABC):
         data, indexed by export.
         """
         tp = self.time_partition
-        # _labels = []
-        # for field_type in tp.field_types:
-        #     _labels.extend(self._label_dict[field_type])
-
         return [
             AttrDict(
                 {

--- a/goalie/function_data.py
+++ b/goalie/function_data.py
@@ -29,10 +29,14 @@ class FunctionData(abc.ABC):
         self.time_partition = time_partition
         self.function_spaces = function_spaces
         self._data = None
-        self.labels = [
-            [label for label in self._label_dict[field]]
-            for field in self.time_partition.field_types
-        ][0]
+        self.labels = (
+            [
+                [label for label in self._label_dict[field]]
+                for field in self.time_partition.field_types
+            ][0]
+            if self.time_partition.fields
+            else []
+        )
 
     def _create_data(self):
         assert self._label_dict

--- a/test/test_function_data.py
+++ b/test/test_function_data.py
@@ -1,6 +1,7 @@
 """
 Unit tests for :class:`~.FunctionData` and its subclasses.
 """
+
 from firedrake import *
 from goalie import *
 import abc
@@ -88,7 +89,36 @@ class BaseTestCases:
                         self.assertTrue(isinstance(f, Function))
 
 
-class TestForwardSolutionData(BaseTestCases.TestFunctionData):
+class TestSteadyForwardSolutionData(BaseTestCases.TestFunctionData):
+    """
+    Unit tests for :class:`~.ForwardSolutionData`.
+    """
+
+    def setUp(self):
+        end_time = 1.0
+        self.num_subintervals = 1
+        timesteps = [1.0]
+        self.field = "field"
+        self.num_exports = [1]
+        self.mesh = UnitTriangleMesh()
+        self.time_partition = TimePartition(
+            end_time, self.num_subintervals, timesteps, self.field
+        )
+        self.function_spaces = {
+            self.field: [
+                FunctionSpace(self.mesh, "DG", 0) for _ in range(self.num_subintervals)
+            ]
+        }
+        self._create_function_data()
+        self.labels = ("forward",)
+
+    def _create_function_data(self):
+        self.solution_data = ForwardSolutionData(
+            self.time_partition, self.function_spaces
+        )
+
+
+class TestUnsteadyForwardSolutionData(BaseTestCases.TestFunctionData):
     """
     Unit tests for :class:`~.ForwardSolutionData`.
     """
@@ -103,7 +133,36 @@ class TestForwardSolutionData(BaseTestCases.TestFunctionData):
         )
 
 
-class TestAdjointSolutionData(BaseTestCases.TestFunctionData):
+class TestSteadyAdjointSolutionData(BaseTestCases.TestFunctionData):
+    """
+    Unit tests for :class:`~.AdjointSolutionData`.
+    """
+
+    def setUp(self):
+        end_time = 1.0
+        self.num_subintervals = 1
+        timesteps = [1.0]
+        self.field = "field"
+        self.num_exports = [1]
+        self.mesh = UnitTriangleMesh()
+        self.time_partition = TimePartition(
+            end_time, self.num_subintervals, timesteps, self.field
+        )
+        self.function_spaces = {
+            self.field: [
+                FunctionSpace(self.mesh, "DG", 0) for _ in range(self.num_subintervals)
+            ]
+        }
+        self._create_function_data()
+        self.labels = ("forward", "adjoint")
+
+    def _create_function_data(self):
+        self.solution_data = AdjointSolutionData(
+            self.time_partition, self.function_spaces
+        )
+
+
+class TestUnsteadyAdjointSolutionData(BaseTestCases.TestFunctionData):
     """
     Unit tests for :class:`~.AdjointSolutionData`.
     """

--- a/test/test_function_data.py
+++ b/test/test_function_data.py
@@ -19,12 +19,30 @@ class BaseTestCases:
         Base class for unit testing subclasses of :class:`~.FunctionData`.
         """
 
-        def setUp(self):
+        def setUpUnsteady(self):
             end_time = 1.0
             self.num_subintervals = 2
             timesteps = [0.5, 0.25]
             self.field = "field"
             self.num_exports = [1, 2]
+            self.mesh = UnitTriangleMesh()
+            self.time_partition = TimePartition(
+                end_time, self.num_subintervals, timesteps, self.field
+            )
+            self.function_spaces = {
+                self.field: [
+                    FunctionSpace(self.mesh, "DG", 0)
+                    for _ in range(self.num_subintervals)
+                ]
+            }
+            self._create_function_data()
+
+        def setUpSteady(self):
+            end_time = 1.0
+            self.num_subintervals = 1
+            timesteps = [1.0]
+            self.field = "field"
+            self.num_exports = [1]
             self.mesh = UnitTriangleMesh()
             self.time_partition = TimePartition(
                 end_time, self.num_subintervals, timesteps, self.field
@@ -95,21 +113,7 @@ class TestSteadyForwardSolutionData(BaseTestCases.TestFunctionData):
     """
 
     def setUp(self):
-        end_time = 1.0
-        self.num_subintervals = 1
-        timesteps = [1.0]
-        self.field = "field"
-        self.num_exports = [1]
-        self.mesh = UnitTriangleMesh()
-        self.time_partition = TimePartition(
-            end_time, self.num_subintervals, timesteps, self.field
-        )
-        self.function_spaces = {
-            self.field: [
-                FunctionSpace(self.mesh, "DG", 0) for _ in range(self.num_subintervals)
-            ]
-        }
-        self._create_function_data()
+        super().setUpSteady()
         self.labels = ("forward",)
 
     def _create_function_data(self):
@@ -124,7 +128,7 @@ class TestUnsteadyForwardSolutionData(BaseTestCases.TestFunctionData):
     """
 
     def setUp(self):
-        super().setUp()
+        super().setUpUnsteady()
         self.labels = ("forward", "forward_old")
 
     def _create_function_data(self):
@@ -139,21 +143,7 @@ class TestSteadyAdjointSolutionData(BaseTestCases.TestFunctionData):
     """
 
     def setUp(self):
-        end_time = 1.0
-        self.num_subintervals = 1
-        timesteps = [1.0]
-        self.field = "field"
-        self.num_exports = [1]
-        self.mesh = UnitTriangleMesh()
-        self.time_partition = TimePartition(
-            end_time, self.num_subintervals, timesteps, self.field
-        )
-        self.function_spaces = {
-            self.field: [
-                FunctionSpace(self.mesh, "DG", 0) for _ in range(self.num_subintervals)
-            ]
-        }
-        self._create_function_data()
+        super().setUpSteady()
         self.labels = ("forward", "adjoint")
 
     def _create_function_data(self):
@@ -168,7 +158,7 @@ class TestUnsteadyAdjointSolutionData(BaseTestCases.TestFunctionData):
     """
 
     def setUp(self):
-        super().setUp()
+        super().setUpUnsteady()
         self.labels = ("forward", "forward_old", "adjoint", "adjoint_next")
 
     def _create_function_data(self):
@@ -183,7 +173,7 @@ class TestIndicatorData(BaseTestCases.TestFunctionData):
     """
 
     def setUp(self):
-        super().setUp()
+        super().setUpUnsteady()
         self.labels = ("error_indicator",)
 
     def _create_function_data(self):


### PR DESCRIPTION
Address issues in #146 by:
- building  `labels` list in both `data_by_label` and `data_by_subfunction` from `self.time_partition.field_types` as was already done in `data_by_field`. 
- added test functionality to include `steady` case in addition to `unsteady` case.